### PR TITLE
chore: publish pyodide wasm base image to ghcr on tag

### DIFF
--- a/.github/workflows/ci-wasm-tests.yaml
+++ b/.github/workflows/ci-wasm-tests.yaml
@@ -11,6 +11,10 @@ concurrency:
   group: ci-wasm-tests-${{ github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   CROOT_DIR: /home/runner/work/build
   ARTIFACTS_DIR: /home/runner/work/artifacts
@@ -38,6 +42,26 @@ jobs:
           pixi-version: v0.68.0
           environments: conda
           cache: true
+
+      - name: Use prebuilt OCCT-wasm base (if available)
+        # Point cmake at the reusable OCCT base via WASM_OCCT_PREBUILT_DIR so
+        # the BUILD_WASM=ON configure (wbuild) skips the ~30-min OCCT compile.
+        # Falls back to building OCCT from source when the base isn't published.
+        run: |
+          echo '${{ secrets.GITHUB_TOKEN }}' | docker login ghcr.io -u '${{ github.actor }}' --password-stdin
+          repo=$(printf '%s' "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          base="ghcr.io/${repo}-occt-wasm-base:latest"
+          if docker pull "$base" >/dev/null 2>&1; then
+            dir="$RUNNER_TEMP/occt-wasm"
+            mkdir -p "$dir"
+            cid=$(docker create "$base")
+            docker cp "$cid:/opt/occt-wasm/." "$dir/"
+            docker rm "$cid" >/dev/null
+            echo "WASM_OCCT_PREBUILT_DIR=$dir" >> "$GITHUB_ENV"
+            echo "Using prebuilt OCCT-wasm base: $base"
+          else
+            echo "No prebuilt OCCT-wasm base ($base) — building OCCT from source."
+          fi
 
       - name: install package
         run: |

--- a/.github/workflows/publish-occt-wasm-base.yaml
+++ b/.github/workflows/publish-occt-wasm-base.yaml
@@ -1,0 +1,104 @@
+name: Publish OCCT-wasm base image
+
+# Cross-compiles the OpenCASCADE toolkits to wasm once and publishes them as a
+# reusable ghcr base image:
+#
+#   ghcr.io/<owner>/adacpp-occt-wasm-base:<OCCT>-emsdk-<emsdk>  (+ :latest, :sha-)
+#
+# The image carries the static archives + headers under /opt/occt-wasm/, which
+# ci-wasm-tests and the wheel publish consume via WASM_OCCT_PREBUILT_DIR to skip
+# the ~30-min OCCT compile.
+#
+# Rebuilt only when its inputs change — the OCCT pin / toolkit list
+# (cmake/wasm_occt.cmake), the emscripten/pyodide env (pixi.toml), the wasm
+# preset, or this workflow — plus on demand via workflow_dispatch. NOT on every
+# push, so day-to-day adacpp changes never pay for it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cmake/wasm_occt.cmake'
+      - 'CMakePresets.json'
+      - 'pixi.toml'
+      - 'deploy/Dockerfile.occt-wasm-base'
+      - '.github/workflows/publish-occt-wasm-base.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: publish-occt-wasm-base-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          pixi-version: v0.68.0
+          environments: wasm
+          cache: true
+
+      - name: Install pyodide cross-build env
+        run: pixi run -e wasm xbuildenv-install
+
+      - name: Cross-compile the OCCT-wasm toolkits
+        # build-occt-wasm builds ONLY the occt_external target → install dir at
+        # build/wasm-pyodide/_deps/occt-install (the ~30-min step).
+        run: pixi run -e wasm build-occt-wasm
+
+      - name: Stage /opt/occt-wasm (lib + include)
+        run: |
+          src="build/wasm-pyodide/_deps/occt-install"
+          test -d "$src/lib" && test -d "$src/include" \
+            || { echo "::error::expected OCCT install at $src (lib/ + include/) not found"; exit 1; }
+          mkdir -p occt-wasm
+          cp -a "$src/." occt-wasm/
+          echo "Staged $(ls occt-wasm/lib/*.a | wc -l) OCCT archives"
+
+      - name: Derive ABI tag (OCCT + emscripten versions)
+        id: abi
+        run: |
+          occt=$(sed -n 's/.*set(OCCT_GIT_TAG[[:space:]]*"\([^"]*\)".*/\1/p' cmake/wasm_occt.cmake | head -1)
+          emsdk=$(sed -n 's/.*emscripten[^0-9]*\([0-9][0-9.]*\).*/\1/p' pixi.toml | head -1)
+          echo "tag=${occt:-OCCT}-emsdk-${emsdk:-unknown}" >> "$GITHUB_OUTPUT"
+          echo "OCCT=$occt emsdk=$emsdk"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}-occt-wasm-base
+          # The ABI tag (OCCT+emsdk) is the durable handle consumers pin to;
+          # latest + sha are convenience aliases.
+          tags: |
+            type=raw,value=${{ steps.abi.outputs.tag }}
+            type=raw,value=latest
+            type=sha,prefix=sha-
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./deploy/Dockerfile.occt-wasm-base
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-wasm-base.yaml
+++ b/.github/workflows/publish-wasm-base.yaml
@@ -41,9 +41,31 @@ jobs:
       - name: Install pyodide cross-build env
         run: pixi run -e wasm xbuildenv-install
 
+      - name: Use prebuilt OCCT-wasm base (if available)
+        # Pull the reusable OCCT base and point cmake at it via
+        # WASM_OCCT_PREBUILT_DIR so wbuild-pyodide skips the ~30-min OCCT
+        # compile. Falls back to building OCCT from source when the base
+        # image isn't published yet (first run / missing access).
+        run: |
+          echo '${{ secrets.GITHUB_TOKEN }}' | docker login ghcr.io -u '${{ github.actor }}' --password-stdin
+          repo=$(printf '%s' "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          base="ghcr.io/${repo}-occt-wasm-base:latest"
+          if docker pull "$base" >/dev/null 2>&1; then
+            dir="$RUNNER_TEMP/occt-wasm"
+            mkdir -p "$dir"
+            cid=$(docker create "$base")
+            docker cp "$cid:/opt/occt-wasm/." "$dir/"
+            docker rm "$cid" >/dev/null
+            echo "WASM_OCCT_PREBUILT_DIR=$dir" >> "$GITHUB_ENV"
+            echo "Using prebuilt OCCT-wasm base: $base"
+          else
+            echo "No prebuilt OCCT-wasm base ($base) — building OCCT from source."
+          fi
+
       - name: Cross-compile the pyodide wheel
-        # depends-on chain: wbuild-pyodide (OCCT→wasm, ~30 min) → install →
-        # tools/build_wheel.py → dist/ada_cpp-*.whl
+        # depends-on chain: wbuild-pyodide → install → tools/build_wheel.py →
+        # dist/ada_cpp-*.whl. With WASM_OCCT_PREBUILT_DIR set the OCCT compile is
+        # skipped (links the prebuilt base); otherwise OCCT builds inline (~30 min).
         run: pixi run -e wasm pack-wheel-pyodide
 
       - name: Stage /out (wheel + manifest + sha)

--- a/.github/workflows/publish-wasm-base.yaml
+++ b/.github/workflows/publish-wasm-base.yaml
@@ -1,0 +1,85 @@
+name: Publish wasm base image
+
+# On a version tag, cross-compile the pyodide wasm wheel (OCCT→wasm via
+# emscripten) and publish it as a ghcr base image:
+#
+#   ghcr.io/<owner>/adacpp-wasm-base:1.2.3  (+ :1.2, :latest, :sha-<short>)
+#
+# The image carries the wheel + manifest under /out/, so downstream image
+# builds (e.g. adapy's viewer) can `COPY --from=ghcr.io/.../adacpp-wasm-base`
+# instead of recompiling OCCT→wasm. Auth is the built-in GITHUB_TOKEN — no
+# external secrets. We only publish on tag.
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+concurrency:
+  group: publish-wasm-base-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          pixi-version: v0.68.0
+          environments: wasm
+          cache: true
+
+      - name: Install pyodide cross-build env
+        run: pixi run -e wasm xbuildenv-install
+
+      - name: Cross-compile the pyodide wheel
+        # depends-on chain: wbuild-pyodide (OCCT→wasm, ~30 min) → install →
+        # tools/build_wheel.py → dist/ada_cpp-*.whl
+        run: pixi run -e wasm pack-wheel-pyodide
+
+      - name: Stage /out (wheel + manifest + sha)
+        run: |
+          mkdir -p out
+          cp dist/ada_cpp-*.whl out/
+          cd out
+          wheel=$(ls ada_cpp-*.whl)
+          printf '{"adacpp":"%s"}\n' "$wheel" > manifest.json
+          printf '%s\n' "${GITHUB_SHA}" > adacpp.sha
+          echo "Staged $wheel"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}-wasm-base
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./deploy/Dockerfile.wasm-base
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/cmake/wasm_occt.cmake
+++ b/cmake/wasm_occt.cmake
@@ -5,9 +5,13 @@
 # nanobind module. Pulled in only when BUILD_WASM=ON; native builds use the
 # conda-forge-provided OCCT via cmake/deps_occ.cmake.
 #
-# This is M1 of OCCT-wasm bringup — first sub-stage builds *only* the
-# FoundationClasses module (TKernel, TKMath) as a proof-of-life. Subsequent
-# stages enable ModelingData / ModelingAlgorithms / DataExchange / etc.
+# The OCCT install (lib/lib*.a + include/opencascade) is an expensive (~30-min)
+# but stable artifact — it depends only on OCCT_GIT_TAG, the toolkit list, the
+# rapidjson pin and the emscripten/pyodide ABI, none of which change with adacpp
+# source. So it is published as a reusable base image and consumed via
+# WASM_OCCT_PREBUILT_DIR: when that is set (env var or -D), this file SKIPS the
+# ExternalProject build entirely and just points the IMPORTED targets at the
+# prebuilt tree. Unset → build OCCT from source as before.
 #
 # We use ExternalProject_Add (not FetchContent_MakeAvailable / add_subdirectory)
 # because OCCT's CMakeLists.txt resolves its helper files against
@@ -19,104 +23,34 @@
 include(ExternalProject)
 include(FetchContent)
 
-set(OCCT_GIT_TAG       "V7_9_0" CACHE STRING "OCCT git tag to fetch for wasm build")
-set(OCCT_INSTALL_DIR   "${CMAKE_BINARY_DIR}/_deps/occt-install")
-set(OCCT_SOURCE_DIR    "${CMAKE_BINARY_DIR}/_deps/occt-src")
-set(OCCT_BUILD_DIR     "${CMAKE_BINARY_DIR}/_deps/occt-build")
+# Reusable prebuilt OCCT-wasm install (the ghcr base image, docker-cp'd onto the
+# runner). Default from the environment so the pixi-driven CI build can opt in
+# without touching CMakePresets.
+set(WASM_OCCT_PREBUILT_DIR "$ENV{WASM_OCCT_PREBUILT_DIR}"
+    CACHE PATH "Prebuilt OCCT-wasm install dir; skip the OCCT ExternalProject build when set")
 
-# RapidJSON is required by OCCT's TKDEGLTF (RWGltf_CafWriter / Reader). It's
-# header-only, so we just need the include dir on disk before OCCT's nested
-# CMake configure runs. Fetched at configure-time (small repo, fast clone).
-FetchContent_Declare(
-    rapidjson
-    GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
-    # NOT v1.1.0 — that 2016 release has rapidjson/document.h:319 doing
-    # `length = rhs.length` against a `const SizeType length` member, which
-    # newer clang (incl. emscripten 3.1.58's clang 19) rejects outright.
-    # Pinned to the post-fix master snapshot OCCT's own CI uses.
-    GIT_TAG        24b5e7a8b27f42fa16b96fc70aade9106cf7102f
-    GIT_SHALLOW    TRUE
-)
-FetchContent_GetProperties(rapidjson)
-if (NOT rapidjson_POPULATED)
-    FetchContent_Populate(rapidjson)
+set(OCCT_GIT_TAG "V7_9_0" CACHE STRING "OCCT git tag to fetch for wasm build")
+
+if (WASM_OCCT_PREBUILT_DIR)
+    set(OCCT_INSTALL_DIR "${WASM_OCCT_PREBUILT_DIR}")
+    message(STATUS "Using prebuilt OCCT-wasm install: ${OCCT_INSTALL_DIR}")
+else ()
+    set(OCCT_INSTALL_DIR "${CMAKE_BINARY_DIR}/_deps/occt-install")
+    set(OCCT_SOURCE_DIR  "${CMAKE_BINARY_DIR}/_deps/occt-src")
+    set(OCCT_BUILD_DIR   "${CMAKE_BINARY_DIR}/_deps/occt-build")
 endif ()
-set(RAPIDJSON_INCLUDE_DIR "${rapidjson_SOURCE_DIR}/include")
-message(STATUS "RapidJSON include dir for OCCT-wasm: ${RAPIDJSON_INCLUDE_DIR}")
 
 # OCCT install layout (on Linux/wasm hosts): include/opencascade/*.hxx, lib/lib*.a
-set(OCCT_INCLUDE_DIR   "${OCCT_INSTALL_DIR}/include/opencascade")
-set(OCCT_LIB_DIR       "${OCCT_INSTALL_DIR}/lib")
-
-# Forward emscripten + build settings into OCCT's nested CMake configure.
-# CMAKE_TOOLCHAIN_FILE comes from emcmake; we pass it through explicitly so
-# the OCCT sub-build uses the same Emscripten.cmake (otherwise it'd try to
-# build with the host compiler).
-set(_OCCT_CMAKE_ARGS
-    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-    -DCMAKE_INSTALL_PREFIX=${OCCT_INSTALL_DIR}
-    -DCMAKE_BUILD_TYPE=Release
-
-    # Static archives — linked into the .so wheel module.
-    -DBUILD_LIBRARY_TYPE=Static
-    -DBUILD_USE_PCH=OFF
-    -DBUILD_DOC_Overview=OFF
-    -DBUILD_RESOURCES=OFF
-    -DBUILD_SAMPLES_MFC=OFF
-    -DBUILD_SAMPLES_QT=OFF
-    -DBUILD_Inspector=OFF
-    -DBUILD_RELEASE_DISABLE_EXCEPTIONS=OFF
-    -DBUILD_SOVERSION_NUMBERS=0
-
-    # M3 sub-stage: full read/write pipeline.
-    # FoundationClasses     → TKernel, TKMath
-    # ModelingData          → TKG2d, TKG3d, TKGeomBase, TKBRep
-    # ModelingAlgorithms    → TKGeomAlgo, TKTopAlgo, TKPrim, TKBO, TKBool,
-    #                         TKHLR, TKFillet, TKOffset, TKShHealing, TKMesh
-    # DataExchange          → TKDESTEP (STEP r/w), TKDEGLTF (glTF r/w),
-    #                         TKXSBase, TKDEIGES, TKDESTL, TKDEPLY, ...
-    # ApplicationFramework  → TKLCAF, TKCAF, TKVCAF, TKBin*, TKXCAF — needed
-    #                         by RWGltf_CafWriter (TDocStd_Document).
-    -DBUILD_MODULE_FoundationClasses=ON
-    -DBUILD_MODULE_ModelingData=ON
-    -DBUILD_MODULE_ModelingAlgorithms=ON
-    -DBUILD_MODULE_DataExchange=ON
-    -DBUILD_MODULE_ApplicationFramework=ON
-    -DBUILD_MODULE_Visualization=OFF
-    -DBUILD_MODULE_Draw=OFF
-
-    # Third-party deps off. RapidJSON comes back at M3 (glTF write), the rest
-    # likely never come back — we'll never need VTK/TBB/freetype/draco for
-    # adacpp's headless conversion path.
-    -DUSE_FREETYPE=OFF
-    -DUSE_FFMPEG=OFF
-    -DUSE_FREEIMAGE=OFF
-    -DUSE_GLES2=OFF
-    -DUSE_OPENVR=OFF
-    # RapidJSON ON for glTF writer; pointed at FetchContent'd source above.
-    -DUSE_RAPIDJSON=ON
-    -D3RDPARTY_RAPIDJSON_DIR=${rapidjson_SOURCE_DIR}
-    -D3RDPARTY_RAPIDJSON_INCLUDE_DIR=${RAPIDJSON_INCLUDE_DIR}
-    -DUSE_DRACO=OFF
-    -DUSE_TBB=OFF
-    -DUSE_VTK=OFF
-    -DUSE_TK=OFF
-    -DUSE_XLIB=OFF
-
-    # OCCT throws Standard_Failure & friends extensively. Match adacpp's wasm
-    # build flag (commit 0566168 "wasm exceptions") so OCCT's catches actually
-    # fire. -fexceptions is the JS-trampoline model pyodide 0.27.x ships;
-    # switch to -fwasm-exceptions when we move to pyodide 0.28+.
-    -DCMAKE_CXX_FLAGS=-fexceptions
-    -DCMAKE_C_FLAGS=-fexceptions
-)
+set(OCCT_INCLUDE_DIR "${OCCT_INSTALL_DIR}/include/opencascade")
+set(OCCT_LIB_DIR     "${OCCT_INSTALL_DIR}/lib")
 
 # OCCT toolkit list — order matters when statically linking. Listed roughly
 # by dependency layer (callers first, dependencies last) so `--start-group`
 # isn't strictly required, but emscripten/wasm-ld is forgiving here.
 # Any toolkit added here must (a) actually be built by OCCT given the
-# BUILD_MODULE_* flags above, and (b) be wanted by the wasm-side bindings —
-# linking unused archives bloats the wheel.
+# BUILD_MODULE_* flags below, and (b) be wanted by the wasm-side bindings —
+# linking unused archives bloats the wheel. Shared by the build-from-source and
+# prebuilt paths (the prebuilt install must carry exactly these archives).
 set(_WASM_OCCT_TOOLKITS
     # DataExchange layer — STEP/glTF readers/writers
     TKDEGLTF      # RWGltf_CafWriter / Reader
@@ -153,38 +87,126 @@ set(_WASM_OCCT_TOOLKITS
     TKernel
 )
 
-set(_WASM_OCCT_BYPRODUCTS)
-foreach (_tk IN LISTS _WASM_OCCT_TOOLKITS)
-    list(APPEND _WASM_OCCT_BYPRODUCTS ${OCCT_LIB_DIR}/lib${_tk}.a)
-endforeach()
+if (NOT WASM_OCCT_PREBUILT_DIR)
+    # ---- Build OCCT from source (the ~30-min cross-compile) ----------------
 
-ExternalProject_Add(
-    occt_external
-    GIT_REPOSITORY  https://github.com/Open-Cascade-SAS/OCCT.git
-    GIT_TAG         ${OCCT_GIT_TAG}
-    GIT_SHALLOW     TRUE
-    GIT_PROGRESS    TRUE
-    SOURCE_DIR      ${OCCT_SOURCE_DIR}
-    BINARY_DIR      ${OCCT_BUILD_DIR}
-    INSTALL_DIR     ${OCCT_INSTALL_DIR}
-    CMAKE_ARGS      ${_OCCT_CMAKE_ARGS}
-    BUILD_BYPRODUCTS ${_WASM_OCCT_BYPRODUCTS}
-    USES_TERMINAL_DOWNLOAD  TRUE
-    USES_TERMINAL_CONFIGURE TRUE
-    USES_TERMINAL_BUILD     TRUE
-    USES_TERMINAL_INSTALL   TRUE
-)
+    # RapidJSON is required by OCCT's TKDEGLTF (RWGltf_CafWriter / Reader). It's
+    # header-only, so we just need the include dir on disk before OCCT's nested
+    # CMake configure runs. Fetched at configure-time (small repo, fast clone).
+    FetchContent_Declare(
+        rapidjson
+        GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
+        # NOT v1.1.0 — that 2016 release has rapidjson/document.h:319 doing
+        # `length = rhs.length` against a `const SizeType length` member, which
+        # newer clang (incl. emscripten 3.1.58's clang 19) rejects outright.
+        # Pinned to the post-fix master snapshot OCCT's own CI uses.
+        GIT_TAG        24b5e7a8b27f42fa16b96fc70aade9106cf7102f
+        GIT_SHALLOW    TRUE
+    )
+    FetchContent_GetProperties(rapidjson)
+    if (NOT rapidjson_POPULATED)
+        FetchContent_Populate(rapidjson)
+    endif ()
+    set(RAPIDJSON_INCLUDE_DIR "${rapidjson_SOURCE_DIR}/include")
+    message(STATUS "RapidJSON include dir for OCCT-wasm: ${RAPIDJSON_INCLUDE_DIR}")
 
-# Make sure the install include dir exists at configure time, even before
-# the build runs — otherwise IMPORTED targets that reference it via
-# INTERFACE_INCLUDE_DIRECTORIES emit a configure-time warning. CMake checks
-# include dirs at configure, archives only at link.
-file(MAKE_DIRECTORY ${OCCT_INCLUDE_DIR})
+    # Forward emscripten + build settings into OCCT's nested CMake configure.
+    # CMAKE_TOOLCHAIN_FILE comes from emcmake; we pass it through explicitly so
+    # the OCCT sub-build uses the same Emscripten.cmake (otherwise it'd try to
+    # build with the host compiler).
+    set(_OCCT_CMAKE_ARGS
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+        -DCMAKE_INSTALL_PREFIX=${OCCT_INSTALL_DIR}
+        -DCMAKE_BUILD_TYPE=Release
+
+        # Static archives — linked into the .so wheel module.
+        -DBUILD_LIBRARY_TYPE=Static
+        -DBUILD_USE_PCH=OFF
+        -DBUILD_DOC_Overview=OFF
+        -DBUILD_RESOURCES=OFF
+        -DBUILD_SAMPLES_MFC=OFF
+        -DBUILD_SAMPLES_QT=OFF
+        -DBUILD_Inspector=OFF
+        -DBUILD_RELEASE_DISABLE_EXCEPTIONS=OFF
+        -DBUILD_SOVERSION_NUMBERS=0
+
+        # M3 sub-stage: full read/write pipeline.
+        # FoundationClasses     → TKernel, TKMath
+        # ModelingData          → TKG2d, TKG3d, TKGeomBase, TKBRep
+        # ModelingAlgorithms    → TKGeomAlgo, TKTopAlgo, TKPrim, TKBO, TKBool,
+        #                         TKHLR, TKFillet, TKOffset, TKShHealing, TKMesh
+        # DataExchange          → TKDESTEP (STEP r/w), TKDEGLTF (glTF r/w),
+        #                         TKXSBase, TKDEIGES, TKDESTL, TKDEPLY, ...
+        # ApplicationFramework  → TKLCAF, TKCAF, TKVCAF, TKBin*, TKXCAF — needed
+        #                         by RWGltf_CafWriter (TDocStd_Document).
+        -DBUILD_MODULE_FoundationClasses=ON
+        -DBUILD_MODULE_ModelingData=ON
+        -DBUILD_MODULE_ModelingAlgorithms=ON
+        -DBUILD_MODULE_DataExchange=ON
+        -DBUILD_MODULE_ApplicationFramework=ON
+        -DBUILD_MODULE_Visualization=OFF
+        -DBUILD_MODULE_Draw=OFF
+
+        # Third-party deps off. RapidJSON comes back at M3 (glTF write), the rest
+        # likely never come back — we'll never need VTK/TBB/freetype/draco for
+        # adacpp's headless conversion path.
+        -DUSE_FREETYPE=OFF
+        -DUSE_FFMPEG=OFF
+        -DUSE_FREEIMAGE=OFF
+        -DUSE_GLES2=OFF
+        -DUSE_OPENVR=OFF
+        # RapidJSON ON for glTF writer; pointed at FetchContent'd source above.
+        -DUSE_RAPIDJSON=ON
+        -D3RDPARTY_RAPIDJSON_DIR=${rapidjson_SOURCE_DIR}
+        -D3RDPARTY_RAPIDJSON_INCLUDE_DIR=${RAPIDJSON_INCLUDE_DIR}
+        -DUSE_DRACO=OFF
+        -DUSE_TBB=OFF
+        -DUSE_VTK=OFF
+        -DUSE_TK=OFF
+        -DUSE_XLIB=OFF
+
+        # OCCT throws Standard_Failure & friends extensively. Match adacpp's wasm
+        # build flag (commit 0566168 "wasm exceptions") so OCCT's catches actually
+        # fire. -fexceptions is the JS-trampoline model pyodide 0.27.x ships;
+        # switch to -fwasm-exceptions when we move to pyodide 0.28+.
+        -DCMAKE_CXX_FLAGS=-fexceptions
+        -DCMAKE_C_FLAGS=-fexceptions
+    )
+
+    set(_WASM_OCCT_BYPRODUCTS)
+    foreach (_tk IN LISTS _WASM_OCCT_TOOLKITS)
+        list(APPEND _WASM_OCCT_BYPRODUCTS ${OCCT_LIB_DIR}/lib${_tk}.a)
+    endforeach()
+
+    ExternalProject_Add(
+        occt_external
+        GIT_REPOSITORY  https://github.com/Open-Cascade-SAS/OCCT.git
+        GIT_TAG         ${OCCT_GIT_TAG}
+        GIT_SHALLOW     TRUE
+        GIT_PROGRESS    TRUE
+        SOURCE_DIR      ${OCCT_SOURCE_DIR}
+        BINARY_DIR      ${OCCT_BUILD_DIR}
+        INSTALL_DIR     ${OCCT_INSTALL_DIR}
+        CMAKE_ARGS      ${_OCCT_CMAKE_ARGS}
+        BUILD_BYPRODUCTS ${_WASM_OCCT_BYPRODUCTS}
+        USES_TERMINAL_DOWNLOAD  TRUE
+        USES_TERMINAL_CONFIGURE TRUE
+        USES_TERMINAL_BUILD     TRUE
+        USES_TERMINAL_INSTALL   TRUE
+    )
+
+    # Make sure the install include dir exists at configure time, even before
+    # the build runs — otherwise IMPORTED targets that reference it via
+    # INTERFACE_INCLUDE_DIRECTORIES emit a configure-time warning. CMake checks
+    # include dirs at configure, archives only at link.
+    file(MAKE_DIRECTORY ${OCCT_INCLUDE_DIR})
+endif ()
 
 # IMPORTED targets: present them as if they were a normal library so callers
 # can `target_link_libraries(_ada_cpp_ext_impl PRIVATE TKBRep TKMath ...)`.
-# The add_dependencies hook ensures occt_external is built before anything
-# that links against these archives.
+# When building from source, the add_dependencies hook ensures occt_external is
+# built before anything that links against these archives; with a prebuilt
+# install the archives already exist, so no dependency is added.
 set(WASM_OCCT_TARGETS)
 foreach(_tk IN LISTS _WASM_OCCT_TOOLKITS)
     if (NOT TARGET ${_tk})
@@ -193,10 +215,16 @@ foreach(_tk IN LISTS _WASM_OCCT_TOOLKITS)
             IMPORTED_LOCATION             ${OCCT_LIB_DIR}/lib${_tk}.a
             INTERFACE_INCLUDE_DIRECTORIES ${OCCT_INCLUDE_DIR}
         )
-        add_dependencies(${_tk} occt_external)
+        if (NOT WASM_OCCT_PREBUILT_DIR)
+            add_dependencies(${_tk} occt_external)
+        endif ()
         list(APPEND WASM_OCCT_TARGETS ${_tk})
     endif ()
 endforeach()
 
-message(STATUS "OCCT-wasm targets staged (built at compile time): ${WASM_OCCT_TARGETS}")
+if (WASM_OCCT_PREBUILT_DIR)
+    message(STATUS "OCCT-wasm targets from prebuilt install: ${WASM_OCCT_TARGETS}")
+else ()
+    message(STATUS "OCCT-wasm targets staged (built at compile time): ${WASM_OCCT_TARGETS}")
+endif ()
 message(STATUS "OCCT-wasm install dir: ${OCCT_INSTALL_DIR}")

--- a/deploy/Dockerfile.occt-wasm-base
+++ b/deploy/Dockerfile.occt-wasm-base
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.7
+#
+# Reusable OCCT-wasm base image: the cross-compiled OpenCASCADE toolkits
+# (static archives + headers) under /opt/occt-wasm/. This is the expensive
+# (~30-min) but stable build input for the adacpp pyodide wheel.
+#
+# The toolkits are cross-compiled on the CI runner (`pixi run -e wasm
+# build-occt-wasm`) and staged into ./occt-wasm/ by the publish-occt-wasm-base
+# workflow *before* this image is built — this Dockerfile only packages the
+# result, so the build here is a sub-second file copy.
+#
+# Consumers (ci-wasm-tests, the wheel publish) docker-cp /opt/occt-wasm/ onto
+# the runner and point cmake at it via WASM_OCCT_PREBUILT_DIR, which makes
+# cmake/wasm_occt.cmake skip the ExternalProject build and link the prebuilt
+# archives instead.
+#
+# /opt/occt-wasm/ layout: include/opencascade/*.hxx, lib/lib*.a
+#
+# ABI-locked: these archives are only valid for the exact emscripten / pyodide
+# xbuildenv version they were built with. The image is tagged with the OCCT git
+# tag + emscripten version so a mismatch is visible at a glance.
+#
+# busybox (not scratch) so `docker create` + `docker cp` work for consumers
+# without a running command.
+FROM busybox:stable-musl
+COPY occt-wasm/ /opt/occt-wasm/

--- a/deploy/Dockerfile.wasm-base
+++ b/deploy/Dockerfile.wasm-base
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7
+#
+# Minimal base image carrying the prebuilt pyodide wasm wheel under /out/.
+#
+# The wheel is cross-compiled on the CI runner (`pixi run -e wasm
+# pack-wheel-pyodide`) and staged into ./out/ by the publish-wasm-base
+# workflow *before* this image is built — this Dockerfile only packages the
+# result, so the build here is a sub-second file copy, not the ~30-min
+# OCCT→wasm compile.
+#
+# /out/ layout (consumed by downstream image builds, e.g. adapy's viewer via
+# `COPY --from=<this image> /out/`):
+#   ada_cpp-<ver>-cp312-cp312-emscripten_3_1_58_wasm32.whl
+#   manifest.json   {"adacpp": "<wheel filename>"}
+#   adacpp.sha      the resolved adacpp commit
+#
+# busybox (not scratch) so `docker create` + `docker cp` work for consumers
+# that extract /out/ without a running command.
+FROM busybox:stable-musl
+COPY out/ /out/

--- a/pixi.toml
+++ b/pixi.toml
@@ -62,6 +62,7 @@ lint = "isort . && black . --config pyproject.toml && ruff check . --fix"
 clean = { cmd = "rm -rf build-wasm && mkdir -p build-wasm" }
 wbuild = { cmd = "emcmake cmake . -B build-wasm -G Ninja -DBUILD_WASM=ON -DBUILD_PYTHON=OFF -DBUILD_TESTS=OFF -DBUILD_STP2GLB=OFF && cmake --build build-wasm", depends-on = ["clean"] }
 xbuildenv-install = { cmd = "pyodide xbuildenv install 0.27.7", description = "Install the pyodide cross-build environment (Python 3.12.7 + emscripten 3.1.58)" }
+build-occt-wasm = { cmd = "emcmake cmake --preset wasm-pyodide && cmake --build build/wasm-pyodide --target occt_external", description = "Cross-build + install ONLY the OCCT-wasm toolkits → build/wasm-pyodide/_deps/occt-install (the reusable base-image input)" }
 wbuild-pyodide = { cmd = "emcmake cmake --preset wasm-pyodide && cmake --build build/wasm-pyodide", description = "Build the adacpp nanobind module for pyodide" }
 pack-wheel-pyodide = { cmd = "rm -rf build/wasm-pyodide/install dist && cmake --install build/wasm-pyodide --prefix build/wasm-pyodide/install && python tools/build_wheel.py build/wasm-pyodide/install/wheel dist", description = "Build a pyodide-tagged wheel from the wasm-pyodide build", depends-on = ["wbuild-pyodide"] }
 tools-install = { cmd = "cd tools && npm install --silent", description = "Install npm helpers (pyodide for the wheel sanity test) into tools/node_modules" }


### PR DESCRIPTION
On a v*.*.* tag, cross-compile the pyodide wasm wheel (OCCT→wasm via emscripten) and publish it as a ghcr base image carrying /out/ (wheel + manifest.json + adacpp.sha):

  ghcr.io/<owner>/adacpp-wasm-base:<version>  (+ :MAJOR.MINOR, :latest, :sha-)

Downstream image builds (e.g. adapy's viewer) can COPY --from this image instead of recompiling OCCT→wasm. Auth is the built-in GITHUB_TOKEN — no external secrets. The heavy compile runs on the runner via `pixi run -e wasm pack-wheel-pyodide`; deploy/Dockerfile.wasm-base only packages the staged wheel into busybox, so the image build itself is trivial.