### PR TITLE
fix: bump setup-pixi to v0.9.6 across CI workflows

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install OpenGL dependencies
         run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev
 
-      - uses: prefix-dev/setup-pixi@v0.9.3
+      - uses: prefix-dev/setup-pixi@v0.9.6
         with:
           pixi-version: latest
           environments: test

--- a/.github/workflows/ci-wasm-tests.yaml
+++ b/.github/workflows/ci-wasm-tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install OpenGL dependencies
         run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev
 
-      - uses: prefix-dev/setup-pixi@v0.9.3
+      - uses: prefix-dev/setup-pixi@v0.9.6
         with:
           pixi-version: v0.68.0
           environments: conda

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - uses: prefix-dev/setup-pixi@v0.9.3  # https://github.com/prefix-dev/setup-pixi
+      - uses: prefix-dev/setup-pixi@v0.9.6  # https://github.com/prefix-dev/setup-pixi
         with:
           pixi-version: latest
           cache: true
@@ -46,7 +46,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - uses: prefix-dev/setup-pixi@v0.9.3
+      - uses: prefix-dev/setup-pixi@v0.9.6
         with:
           pixi-version: latest
           environments: conda

--- a/.github/workflows/publish-occt-wasm-base.yaml
+++ b/.github/workflows/publish-occt-wasm-base.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.9.3
+      - uses: prefix-dev/setup-pixi@v0.9.6
         with:
           pixi-version: v0.68.0
           environments: wasm

--- a/.github/workflows/publish-wasm-base.yaml
+++ b/.github/workflows/publish-wasm-base.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.9.3
+      - uses: prefix-dev/setup-pixi@v0.9.6
         with:
           pixi-version: v0.68.0
           environments: wasm


### PR DESCRIPTION
Bumps `prefix-dev/setup-pixi` from `v0.9.3` to `v0.9.6` across all CI/publish workflows.

The primary purpose is to land a `fix:` commit on `main` so the semantic-version action cuts a **0.4.2** patch release. That release build will pull the newly dispatched OCCT base image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)