### PR TITLE
feat: cylindrical/conical/toroidal AdvancedFace builders

### DIFF
--- a/src/adacpp/cad/__init__.py
+++ b/src/adacpp/cad/__init__.py
@@ -45,6 +45,8 @@ build_bspline_surface_face = _cad.build_bspline_surface_face
 build_advanced_face_bspline = _cad.build_advanced_face_bspline
 build_advanced_face_planar = _cad.build_advanced_face_planar
 build_advanced_face_cylindrical = _cad.build_advanced_face_cylindrical
+build_advanced_face_conical = _cad.build_advanced_face_conical
+build_advanced_face_toroidal = _cad.build_advanced_face_toroidal
 face_to_advanced_face = _cad.face_to_advanced_face
 extrude_face_along_normal = _cad.extrude_face_along_normal
 build_face_based_surface_model = _cad.build_face_based_surface_model
@@ -127,6 +129,8 @@ __all__ = [
     "build_advanced_face_bspline",
     "build_advanced_face_planar",
     "build_advanced_face_cylindrical",
+    "build_advanced_face_conical",
+    "build_advanced_face_toroidal",
     "face_to_advanced_face",
     "extrude_face_along_normal",
     "build_face_based_surface_model",

--- a/src/adacpp/cad/__init__.py
+++ b/src/adacpp/cad/__init__.py
@@ -44,6 +44,7 @@ build_filled_face = _cad.build_filled_face
 build_bspline_surface_face = _cad.build_bspline_surface_face
 build_advanced_face_bspline = _cad.build_advanced_face_bspline
 build_advanced_face_planar = _cad.build_advanced_face_planar
+build_advanced_face_cylindrical = _cad.build_advanced_face_cylindrical
 face_to_advanced_face = _cad.face_to_advanced_face
 extrude_face_along_normal = _cad.extrude_face_along_normal
 build_face_based_surface_model = _cad.build_face_based_surface_model
@@ -125,6 +126,7 @@ __all__ = [
     "build_bspline_surface_face",
     "build_advanced_face_bspline",
     "build_advanced_face_planar",
+    "build_advanced_face_cylindrical",
     "face_to_advanced_face",
     "extrude_face_along_normal",
     "build_face_based_surface_model",

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -62,6 +62,7 @@
 #include <ShapeFix_Shape.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_BSplineSurface.hxx>
+#include <Geom_CylindricalSurface.hxx>
 #include <Geom_Surface.hxx>
 #include <Geom2d_BSplineCurve.hxx>
 #include <Geom2d_Curve.hxx>
@@ -1338,6 +1339,43 @@ ShapeHandle build_advanced_face_planar_impl(
     return ShapeHandle(fixer.Face());
 }
 
+// Bounds-trimmed AdvancedFace over a Geom_CylindricalSurface (tube/pipe walls).
+// Unlike the planar path the surface is NOT inferred from the wire — loc/axis/
+// ref_dir/radius position the cylinder explicitly, then the boundary wire trims
+// it. The 3D boundary edges (axis-parallel LINEs + CIRCLE arcs) carry no UV
+// p-curve, so ShapeFix_Face projects them onto the cylinder and SameParameter
+// reconciles 3D/2D so BRepMesh can grid the face. Mirrors adapy's
+// make_closed_shell_from_geom AdvancedFace(CylindricalSurface) path.
+ShapeHandle build_advanced_face_cylindrical_impl(
+        std::array<double, 3> loc, std::array<double, 3> axis,
+        std::array<double, 3> ref_dir, double radius,
+        const std::vector<std::vector<std::vector<double>>> &bounds) {
+    if (bounds.empty()) throw std::runtime_error("build_advanced_face_cylindrical: no bounds");
+
+    const gp_Ax3 ax3(gp_Pnt(loc[0], loc[1], loc[2]), gp_Dir(axis[0], axis[1], axis[2]),
+                     gp_Dir(ref_dir[0], ref_dir[1], ref_dir[2]));
+    Handle(Geom_CylindricalSurface) surf = new Geom_CylindricalSurface(ax3, radius);
+
+    auto wire_of = [&](const std::vector<std::vector<double>> &edges) -> TopoDS_Wire {
+        BRepBuilderAPI_MakeWire wm;
+        for (const auto &rec : edges) wm.Add(edge_from_record(rec));
+        wm.Build();
+        if (!wm.IsDone()) throw std::runtime_error("build_advanced_face_cylindrical: wire build failed");
+        return wm.Wire();
+    };
+
+    BRepBuilderAPI_MakeFace fm(surf, wire_of(bounds[0]), Standard_True);
+    for (std::size_t b = 1; b < bounds.size(); ++b) fm.Add(wire_of(bounds[b]));
+    if (!fm.IsDone()) throw std::runtime_error("build_advanced_face_cylindrical: MakeFace failed");
+
+    TopoDS_Face face = fm.Face();
+    ShapeFix_Face fixer(face);
+    fixer.Perform();
+    face = fixer.Face();
+    BRepLib::SameParameter(face, 1.0e-6, Standard_True);
+    return ShapeHandle(face);
+}
+
 // Extract the 2D UV pcurve of an edge on a face (BRep_Tool::CurveOnSurface →
 // trim → Geom2dConvert::CurveToBSplineCurve), plus the edge's 3D endpoints.
 // Port of adapy's _extract_pcurve + _edge_endpoints. has_pcurve=false when OCC
@@ -2133,6 +2171,13 @@ void cad_module(nb::module_ &m) {
           "Bounds-trimmed AdvancedFace over a Plane inferred from the (planar) boundary wire "
           "(MakeFace OnlyPlane). bounds[0] outer, rest holes; 3D edge records. loc/axis/ref_dir "
           "are accepted for parity but unused. Ports make_closed_shell_from_geom's planar path.");
+
+    m.def("build_advanced_face_cylindrical", &build_advanced_face_cylindrical_impl,
+          "loc"_a, "axis"_a, "ref_dir"_a, "radius"_a, "bounds"_a,
+          "Bounds-trimmed AdvancedFace over a Geom_CylindricalSurface. loc is the cylinder "
+          "axis base, axis its direction, ref_dir the U reference, radius its radius. bounds[0] "
+          "outer, rest holes; 3D edge records (LINE/CIRCLE). Ports make_closed_shell_from_geom's "
+          "AdvancedFace(CylindricalSurface) path for tube/pipe walls.");
 
     m.def("face_to_advanced_face", &face_to_advanced_face_impl, "face"_a,
           "Decompose a B-spline face into AdvancedFaceData (surface poles/knots + per-wire "

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -62,7 +62,9 @@
 #include <ShapeFix_Shape.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_BSplineSurface.hxx>
+#include <Geom_ConicalSurface.hxx>
 #include <Geom_CylindricalSurface.hxx>
+#include <Geom_ToroidalSurface.hxx>
 #include <Geom_Surface.hxx>
 #include <Geom2d_BSplineCurve.hxx>
 #include <Geom2d_Curve.hxx>
@@ -1339,34 +1341,28 @@ ShapeHandle build_advanced_face_planar_impl(
     return ShapeHandle(fixer.Face());
 }
 
-// Bounds-trimmed AdvancedFace over a Geom_CylindricalSurface (tube/pipe walls).
-// Unlike the planar path the surface is NOT inferred from the wire — loc/axis/
-// ref_dir/radius position the cylinder explicitly, then the boundary wire trims
-// it. The 3D boundary edges (axis-parallel LINEs + CIRCLE arcs) carry no UV
-// p-curve, so ShapeFix_Face projects them onto the cylinder and SameParameter
-// reconciles 3D/2D so BRepMesh can grid the face. Mirrors adapy's
-// make_closed_shell_from_geom AdvancedFace(CylindricalSurface) path.
-ShapeHandle build_advanced_face_cylindrical_impl(
-        std::array<double, 3> loc, std::array<double, 3> axis,
-        std::array<double, 3> ref_dir, double radius,
-        const std::vector<std::vector<std::vector<double>>> &bounds) {
-    if (bounds.empty()) throw std::runtime_error("build_advanced_face_cylindrical: no bounds");
-
-    const gp_Ax3 ax3(gp_Pnt(loc[0], loc[1], loc[2]), gp_Dir(axis[0], axis[1], axis[2]),
-                     gp_Dir(ref_dir[0], ref_dir[1], ref_dir[2]));
-    Handle(Geom_CylindricalSurface) surf = new Geom_CylindricalSurface(ax3, radius);
+// Bounds-trimmed AdvancedFace over an explicitly-positioned analytic surface
+// (cylinder / cone / torus). Unlike the planar path the surface is NOT inferred
+// from the wire; the boundary wire trims the given surface. The 3D boundary edges
+// (LINEs + CIRCLE arcs) carry no UV p-curve, so ShapeFix_Face projects them onto
+// the surface and SameParameter reconciles 3D/2D so BRepMesh can grid the face.
+// Mirrors adapy's make_closed_shell_from_geom analytic AdvancedFace path.
+static ShapeHandle bounds_trimmed_analytic_face(
+        const Handle(Geom_Surface) &surf,
+        const std::vector<std::vector<std::vector<double>>> &bounds, const char *who) {
+    if (bounds.empty()) throw std::runtime_error(std::string(who) + ": no bounds");
 
     auto wire_of = [&](const std::vector<std::vector<double>> &edges) -> TopoDS_Wire {
         BRepBuilderAPI_MakeWire wm;
         for (const auto &rec : edges) wm.Add(edge_from_record(rec));
         wm.Build();
-        if (!wm.IsDone()) throw std::runtime_error("build_advanced_face_cylindrical: wire build failed");
+        if (!wm.IsDone()) throw std::runtime_error(std::string(who) + ": wire build failed");
         return wm.Wire();
     };
 
     BRepBuilderAPI_MakeFace fm(surf, wire_of(bounds[0]), Standard_True);
     for (std::size_t b = 1; b < bounds.size(); ++b) fm.Add(wire_of(bounds[b]));
-    if (!fm.IsDone()) throw std::runtime_error("build_advanced_face_cylindrical: MakeFace failed");
+    if (!fm.IsDone()) throw std::runtime_error(std::string(who) + ": MakeFace failed");
 
     TopoDS_Face face = fm.Face();
     ShapeFix_Face fixer(face);
@@ -1374,6 +1370,37 @@ ShapeHandle build_advanced_face_cylindrical_impl(
     face = fixer.Face();
     BRepLib::SameParameter(face, 1.0e-6, Standard_True);
     return ShapeHandle(face);
+}
+
+static gp_Ax3 _ax3(const std::array<double, 3> &loc, const std::array<double, 3> &axis,
+                   const std::array<double, 3> &ref_dir) {
+    return gp_Ax3(gp_Pnt(loc[0], loc[1], loc[2]), gp_Dir(axis[0], axis[1], axis[2]),
+                  gp_Dir(ref_dir[0], ref_dir[1], ref_dir[2]));
+}
+
+ShapeHandle build_advanced_face_cylindrical_impl(
+        std::array<double, 3> loc, std::array<double, 3> axis,
+        std::array<double, 3> ref_dir, double radius,
+        const std::vector<std::vector<std::vector<double>>> &bounds) {
+    Handle(Geom_CylindricalSurface) surf = new Geom_CylindricalSurface(_ax3(loc, axis, ref_dir), radius);
+    return bounds_trimmed_analytic_face(surf, bounds, "build_advanced_face_cylindrical");
+}
+
+ShapeHandle build_advanced_face_conical_impl(
+        std::array<double, 3> loc, std::array<double, 3> axis,
+        std::array<double, 3> ref_dir, double radius, double semi_angle,
+        const std::vector<std::vector<std::vector<double>>> &bounds) {
+    // Geom_ConicalSurface(ax3, semi_angle, ref_radius)
+    Handle(Geom_ConicalSurface) surf = new Geom_ConicalSurface(_ax3(loc, axis, ref_dir), semi_angle, radius);
+    return bounds_trimmed_analytic_face(surf, bounds, "build_advanced_face_conical");
+}
+
+ShapeHandle build_advanced_face_toroidal_impl(
+        std::array<double, 3> loc, std::array<double, 3> axis,
+        std::array<double, 3> ref_dir, double major_radius, double minor_radius,
+        const std::vector<std::vector<std::vector<double>>> &bounds) {
+    Handle(Geom_ToroidalSurface) surf = new Geom_ToroidalSurface(_ax3(loc, axis, ref_dir), major_radius, minor_radius);
+    return bounds_trimmed_analytic_face(surf, bounds, "build_advanced_face_toroidal");
 }
 
 // Extract the 2D UV pcurve of an edge on a face (BRep_Tool::CurveOnSurface →
@@ -2178,6 +2205,16 @@ void cad_module(nb::module_ &m) {
           "axis base, axis its direction, ref_dir the U reference, radius its radius. bounds[0] "
           "outer, rest holes; 3D edge records (LINE/CIRCLE). Ports make_closed_shell_from_geom's "
           "AdvancedFace(CylindricalSurface) path for tube/pipe walls.");
+
+    m.def("build_advanced_face_conical", &build_advanced_face_conical_impl,
+          "loc"_a, "axis"_a, "ref_dir"_a, "radius"_a, "semi_angle"_a, "bounds"_a,
+          "Bounds-trimmed AdvancedFace over a Geom_ConicalSurface (radius at the axis base, "
+          "semi_angle the half-angle). bounds[0] outer, rest holes; 3D edge records.");
+
+    m.def("build_advanced_face_toroidal", &build_advanced_face_toroidal_impl,
+          "loc"_a, "axis"_a, "ref_dir"_a, "major_radius"_a, "minor_radius"_a, "bounds"_a,
+          "Bounds-trimmed AdvancedFace over a Geom_ToroidalSurface (pipe elbows). "
+          "bounds[0] outer, rest holes; 3D edge records.");
 
     m.def("face_to_advanced_face", &face_to_advanced_face_impl, "face"_a,
           "Decompose a B-spline face into AdvancedFaceData (surface poles/knots + per-wire "

--- a/tests/py/test_basic.py
+++ b/tests/py/test_basic.py
@@ -349,6 +349,44 @@ def test_cad_build_advanced_face_cylindrical():
     assert len(mesh.indices) > 0
 
 
+def test_cad_build_advanced_face_conical():
+    # Half cone-frustum band (apex at origin, axis +Z, semi_angle=45deg so r=1+z),
+    # angle 0..pi, between z=0 (r=1) and z=1 (r=2): two CIRCLE arcs + two generatrix
+    # LINE edges (each a straight line on the cone). Surface must be a cone + tessellate.
+    import math
+
+    bottom = [1.0, 1, 0, 0, 0, 1, 0, -1, 0, 0]  # arc z=0 r=1
+    right = [0.0, -1, 0, 0, -2, 0, 1]  # generatrix at angle pi: (-1,0,0)->(-2,0,1)
+    top = [1.0, -2, 0, 1, 0, 2, 1, 2, 0, 1]  # arc z=1 r=2
+    left = [0.0, 2, 0, 1, 1, 0, 0]  # generatrix at angle 0: (2,0,1)->(1,0,0)
+    bounds = [[bottom, right, top, left]]
+
+    face = adacpp.cad.build_advanced_face_conical([0, 0, 0], [0, 0, 1], [1, 0, 0], 1.0, math.pi / 4, bounds)
+    assert adacpp.cad.shape_type(face) == "face"
+    assert adacpp.cad.face_surface_type(face) == "cone"
+    mesh = adacpp.cad.tessellate(face, 0.05)
+    assert len(mesh.positions) > 0 and len(mesh.indices) > 0
+
+
+def test_cad_build_advanced_face_toroidal():
+    # Quarter-quarter torus patch (major R=3, minor r=1): u 0..pi/2, v 0..pi/2,
+    # bounded by four CIRCLE arcs (two major, two minor). Surface must be a torus.
+    import math
+
+    s = 1.0 / math.sqrt(2.0)
+    e1 = [1.0, 4, 0, 0, 4 * s, 4 * s, 0, 0, 4, 0]  # v=0 outer arc (R+r=4), z=0
+    e2 = [1.0, 0, 4, 0, 0, 3 + s, s, 0, 3, 1]  # u=pi/2 minor arc about (0,3,0)
+    e3 = [1.0, 0, 3, 1, 3 * s, 3 * s, 1, 3, 0, 1]  # v=pi/2 arc (R=3), z=1
+    e4 = [1.0, 3, 0, 1, 3 + s, 0, s, 4, 0, 0]  # u=0 minor arc about (3,0,0)
+    bounds = [[e1, e2, e3, e4]]
+
+    face = adacpp.cad.build_advanced_face_toroidal([0, 0, 0], [0, 0, 1], [1, 0, 0], 3.0, 1.0, bounds)
+    assert adacpp.cad.shape_type(face) == "face"
+    assert adacpp.cad.face_surface_type(face) == "torus"
+    mesh = adacpp.cad.tessellate(face, 0.05)
+    assert len(mesh.positions) > 0 and len(mesh.indices) > 0
+
+
 def test_cad_introspection_helpers():
     # area / shape_type / face_surface_type — backend-neutral replacements for
     # GProp + TopAbs + BRep_Tool::Surface introspection.

--- a/tests/py/test_basic.py
+++ b/tests/py/test_basic.py
@@ -314,13 +314,39 @@ def test_cad_polygon_face():
 def test_cad_build_advanced_face_planar():
     # Planar AdvancedFace from a closed line-edge quad: plane inferred from the wire, one
     # face of the expected area. (bounds[0] outer; loc/axis/ref_dir accepted but unused.)
-    quad = [[0.0, *a, *b] for a, b in zip(
-        [(0, 0, 0), (2, 0, 0), (2, 1, 0), (0, 1, 0)],
-        [(2, 0, 0), (2, 1, 0), (0, 1, 0), (0, 0, 0)],
-    )]
+    quad = [
+        [0.0, *a, *b]
+        for a, b in zip(
+            [(0, 0, 0), (2, 0, 0), (2, 1, 0), (0, 1, 0)],
+            [(2, 0, 0), (2, 1, 0), (0, 1, 0), (0, 0, 0)],
+        )
+    ]
     face = adacpp.cad.build_advanced_face_planar([0, 0, 0], [0, 0, 1], [1, 0, 0], [quad])
     assert adacpp.cad.shape_type(face) == "face"
     assert round(adacpp.cad.area(face), 6) == 2.0
+
+
+def test_cad_build_advanced_face_cylindrical():
+    # Half-cylinder wall patch (r=1, h=2, angle 0..pi) bounded by two CIRCLE arcs
+    # (top/bottom) and two axis-parallel LINE edges. Surface must be a cylinder and
+    # the lateral area pi*r*h = 2*pi; it must also tessellate (p-curves projected).
+    import math
+
+    bottom = [1.0, 1, 0, 0, 0, 1, 0, -1, 0, 0]  # arc start->mid->end at z=0
+    right = [0.0, -1, 0, 0, -1, 0, 2]  # line up at angle pi
+    top = [1.0, -1, 0, 2, 0, 1, 2, 1, 0, 2]  # arc back at z=2
+    left = [0.0, 1, 0, 2, 1, 0, 0]  # line down at angle 0
+    bounds = [[bottom, right, top, left]]
+
+    face = adacpp.cad.build_advanced_face_cylindrical([0, 0, 0], [0, 0, 1], [1, 0, 0], 1.0, bounds)
+    assert adacpp.cad.shape_type(face) == "face"
+    assert adacpp.cad.face_surface_type(face) == "cylinder"
+    # lateral area pi*r*h = 2*pi (sign depends on face orientation)
+    assert round(abs(adacpp.cad.area(face)), 4) == round(2 * math.pi, 4)
+
+    mesh = adacpp.cad.tessellate(face, 0.05)
+    assert len(mesh.positions) > 0
+    assert len(mesh.indices) > 0
 
 
 def test_cad_introspection_helpers():


### PR DESCRIPTION
Add native bounds-trimmed analytic `AdvancedFace` builders so the adapy
`AdacppBackend` can build the curved faces the kernel-free streaming STEP reader
reconstructs — tube/pipe walls, cones, and pipe elbows — bringing the native
backend to parity with OCC on analytic surfaces.

## What
- `build_advanced_face_cylindrical` (`Geom_CylindricalSurface`)
- `build_advanced_face_conical` (`Geom_ConicalSurface`)
- `build_advanced_face_toroidal` (`Geom_ToroidalSurface`)

All three share a `bounds_trimmed_analytic_face` helper: the surface is
positioned explicitly from `loc/axis/ref_dir` (+ radius / semi-angle / minor
radius), then the boundary wire trims it. The 3D boundary edges (LINE + CIRCLE
arcs) carry no UV p-curve, so `ShapeFix_Face` projects them onto the surface and
`SameParameter` reconciles 3D/2D so `BRepMesh` can grid the face. Mirrors adapy's
`make_closed_shell_from_geom` analytic `AdvancedFace` path.

Re-exported from `adacpp.cad` (the Python wrapper allow-lists names), and covered
by half-cylinder, cone-frustum, and quarter-torus patch tests (surface type +
tessellation).

## Why
The streaming STEP reader (adapy) reconstructs `CylindricalSurface` /
`ConicalSurface` / `ToroidalSurface` `AdvancedFace`s for tubes, cones, and pipe
elbows. Released ada-cpp 0.6.0 only builds planar + B-spline faces, so those
tessellations raised `NotImplementedError` under the native backend. With this PR
the native backend covers every analytic `AdvancedFace` the reader produces — only
the periodic **spherical** face (closed in u *and* v) remains.

The adapy adapter (`AdacppBackend.build`) routes these surfaces to the new builders,
`hasattr`-guarded so it activates automatically once this ships and the adapy
`ada-cpp` pin bumps.