### PR TITLE
feat: add build_swept_disk_solid for IfcSweptDiskSolid parity

### DIFF
--- a/src/adacpp/cad/__init__.py
+++ b/src/adacpp/cad/__init__.py
@@ -36,6 +36,7 @@ loft_profiles = _cad.loft_profiles
 section_with_plane = _cad.section_with_plane
 build_revolved_area_solid = _cad.build_revolved_area_solid
 build_fixed_reference_swept_area_solid = _cad.build_fixed_reference_swept_area_solid
+build_swept_disk_solid = _cad.build_swept_disk_solid
 make_halfspace = _cad.make_halfspace
 cut_surfaces = _cad.cut_surfaces
 build_planar_face = _cad.build_planar_face
@@ -120,6 +121,7 @@ __all__ = [
     "section_with_plane",
     "build_revolved_area_solid",
     "build_fixed_reference_swept_area_solid",
+    "build_swept_disk_solid",
     "make_halfspace",
     "cut_surfaces",
     "build_planar_face",

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -1685,6 +1685,48 @@ ShapeHandle build_fixed_reference_swept_area_solid_impl(
     return ShapeHandle(BRepBuilderAPI_Transform(solid, tr, true).Shape());
 }
 
+// Native IfcSweptDiskSolid (pipes / rods): sweep a circular disk (optionally
+// annular) along the directrix. Port of adapy's make_swept_disk_solid_from_geom
+// — the disk is placed at the spine start, normal to the start tangent, and
+// MakePipeShell keeps it perpendicular along the spine; an inner radius is swept
+// the same way and cut out. The directrix arrives as edge records (so any curve
+// kind adapy can encode — line/arc/composite — works uniformly).
+ShapeHandle build_swept_disk_solid_impl(
+        const std::vector<std::vector<double>> &directrix,
+        double radius,
+        double inner_radius) {
+    const TopoDS_Wire spine = wire_from_edges(directrix);
+
+    // Start point + tangent of the spine (a circle is rotationally symmetric, so
+    // the tangent sign is irrelevant — only the plane it defines matters).
+    TopExp_Explorer exp(spine, TopAbs_EDGE);
+    if (!exp.More()) throw std::runtime_error("build_swept_disk_solid: empty directrix");
+    const TopoDS_Edge first_edge = TopoDS::Edge(exp.Current());
+    BRepAdaptor_Curve adaptor(first_edge);
+    gp_Pnt p0;
+    gp_Vec d0;
+    adaptor.D1(adaptor.FirstParameter(), p0, d0);
+    if (d0.Magnitude() < 1e-12) throw std::runtime_error("build_swept_disk_solid: degenerate start tangent");
+    const gp_Ax2 disk_axis(p0, gp_Dir(d0));
+
+    auto sweep = [&](double r) -> TopoDS_Shape {
+        const TopoDS_Edge circ_edge = BRepBuilderAPI_MakeEdge(gp_Circ(disk_axis, r)).Edge();
+        const TopoDS_Wire profile = BRepBuilderAPI_MakeWire(circ_edge).Wire();
+        BRepOffsetAPI_MakePipeShell mps(spine);
+        mps.SetTransitionMode(BRepBuilderAPI_RoundCorner);
+        mps.Add(profile, Standard_True, Standard_False);
+        mps.Build();
+        mps.MakeSolid();
+        return mps.Shape();
+    };
+
+    TopoDS_Shape solid = sweep(radius);
+    if (inner_radius > 0.0) {
+        solid = BRepAlgoAPI_Cut(solid, sweep(inner_radius)).Shape();
+    }
+    return ShapeHandle(solid);
+}
+
 // ----------------------------------------------------------------------------
 // cut_surfaces — extract polyline boundaries of CSG cut faces (native port of
 // adapy's ada.occ.cut_surfaces_occ). Self-contained in adacpp's own OCCT; does
@@ -2165,6 +2207,13 @@ void cad_module(nb::module_ &m) {
           "edge-record encoding as build_extruded_area_solid) with "
           "MakePipeShell + round-corner transitions, make a solid, and "
           "translate to `location`.");
+
+    m.def("build_swept_disk_solid", &build_swept_disk_solid_impl,
+          "directrix"_a, "radius"_a, "inner_radius"_a = 0.0,
+          "Swept-disk solid (IfcSweptDiskSolid — pipes/rods): sweep a circular "
+          "(annular when inner_radius>0) disk along the directrix spine (edge "
+          "records). The disk is placed at the spine start normal to its tangent "
+          "and kept perpendicular by MakePipeShell.");
 
     m.def("make_halfspace", &make_halfspace_impl,
           "origin"_a, "normal"_a, "flip"_a,

--- a/tests/py/test_basic.py
+++ b/tests/py/test_basic.py
@@ -229,6 +229,28 @@ def test_cad_extruded_area_solid_tapered():
     assert bb == (-1.0, -1.0, 0.0, 1.0, 1.0, 2.0)
 
 
+def test_cad_build_swept_disk_solid():
+    # Sweep a disk of radius 0.1 along a straight 1 m directrix (line edge record
+    # [0, p0, p1]) -> a cylinder. Volume = pi*r^2*h.
+    import math
+
+    directrix = [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]]
+    shp = adacpp.cad.build_swept_disk_solid(directrix, 0.1, 0.0)
+    assert adacpp.cad.is_valid(shp)
+    assert adacpp.cad.shape_type(shp) == "solid"
+    assert round(adacpp.cad.volume(shp), 5) == round(math.pi * 0.1**2 * 1.0, 5)
+
+
+def test_cad_build_swept_disk_solid_annular():
+    # Annular disk (tube): outer 0.1, inner 0.05 over 1 m. Volume = pi*(R^2-r^2)*h.
+    import math
+
+    directrix = [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]]
+    shp = adacpp.cad.build_swept_disk_solid(directrix, 0.1, 0.05)
+    assert adacpp.cad.is_valid(shp)
+    assert round(adacpp.cad.volume(shp), 5) == round(math.pi * (0.1**2 - 0.05**2) * 1.0, 5)
+
+
 def test_cad_loft_profiles_two_squares_is_box():
     # Loft two equal squares 1 apart in Z → a unit box: 6 faces, volume 1.
     def rect(half, z):


### PR DESCRIPTION
Adds a native swept-disk-solid builder so adapy's `AdacppBackend` can build `IfcSweptDiskSolid` (pipes/rods) without a pythonocc fallback — part of the CAD-backend parity needed for adapy's new IFC geometry primitives (Krande/adapy#47).

## Change
- **`build_swept_disk_solid(directrix, radius, inner_radius=0.0)`** — sweeps a circular (annular when `inner_radius > 0`) disk along the directrix spine via `BRepOffsetAPI_MakePipeShell`. The disk is placed at the spine start, normal to its start tangent (extracted from the built wire), and kept perpendicular along the spine; an inner radius is swept the same way and cut out. The directrix arrives as edge records (the same encoding as `build_wire` / `build_fixed_reference_swept_area_solid`), so any curve kind adapy encodes — line / arc / composite — works uniformly.
- pybind binding + exposed in `adacpp.cad`.
- Tests: cylinder and annular-tube volume checks (`pi*r^2*h`, `pi*(R^2-r^2)*h`).

## Tests
`pytest tests/py/test_basic.py` — 60 passed (2 new).

The matching adapy dispatch lives on adapy branch `feat/ifc-geom-primitives` (AdacppBackend.build → `build_swept_disk_solid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)