### PR TITLE
feat: native IFC4x3 alignment swept-area solid (no OCC)

### DIFF
--- a/.github/workflows/build-stp2glb.yaml
+++ b/.github/workflows/build-stp2glb.yaml
@@ -25,11 +25,11 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: latest
           environments: stp2glb
@@ -55,7 +55,7 @@ jobs:
           ldd "$bin" || true
 
       - name: upload STP2GLB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: STP2GLB-linux-64
           path: build-stp2glb/STP2GLB
@@ -64,6 +64,6 @@ jobs:
       # On a tag push, also attach the binary to the corresponding GitHub release.
       - name: attach binary to release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: build-stp2glb/STP2GLB

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -25,7 +25,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
@@ -33,7 +33,7 @@ jobs:
       - name: Install OpenGL dependencies
         run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev
 
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: latest
           environments: test

--- a/.github/workflows/ci-wasm-tests.yaml
+++ b/.github/workflows/ci-wasm-tests.yaml
@@ -29,7 +29,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
@@ -37,7 +37,7 @@ jobs:
       - name: Install OpenGL dependencies
         run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev
 
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: v0.68.0
           environments: conda

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -15,11 +15,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - uses: prefix-dev/setup-pixi@v0.9.6  # https://github.com/prefix-dev/setup-pixi
+      - uses: prefix-dev/setup-pixi@v0.10.0  # https://github.com/prefix-dev/setup-pixi
         with:
           pixi-version: latest
           cache: true
@@ -42,11 +42,11 @@ jobs:
           { name: macOS, distver: macos-15, pkg_dir: 'osx-arm64' }
         ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: latest
           environments: conda

--- a/.github/workflows/publish-occt-wasm-base.yaml
+++ b/.github/workflows/publish-occt-wasm-base.yaml
@@ -40,9 +40,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: v0.68.0
           environments: wasm
@@ -73,10 +73,10 @@ jobs:
           echo "tag=${occt:-OCCT}-emsdk-${emsdk:-unknown}" >> "$GITHUB_OUTPUT"
           echo "OCCT=$occt emsdk=$emsdk"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -84,7 +84,7 @@ jobs:
 
       - name: Compute image tags + labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}-occt-wasm-base
           # The ABI tag (OCCT+emsdk) is the durable handle consumers pin to;
@@ -95,7 +95,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push base image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./deploy/Dockerfile.occt-wasm-base

--- a/.github/workflows/publish-wasm-base.yaml
+++ b/.github/workflows/publish-wasm-base.yaml
@@ -30,9 +30,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: v0.68.0
           environments: wasm
@@ -92,10 +92,10 @@ jobs:
           printf '%s\n' "${GITHUB_SHA}" > adacpp.sha
           echo "Staged $wheel + out/wasm/ (adacpp_step_glb + adacpp_glb_diff .js/.wasm)"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Compute image tags + labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}-wasm-base
           tags: |
@@ -112,7 +112,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push base image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./deploy/Dockerfile.wasm-base

--- a/src/adacpp/cad/__init__.py
+++ b/src/adacpp/cad/__init__.py
@@ -29,6 +29,7 @@ step_emit_ifc_brep = _cad.step_emit_ifc_brep
 stream_step_to_step = _cad.stream_step_to_step
 stream_ifc_to_step = _cad.stream_ifc_to_step
 stream_step_to_ifc = _cad.stream_step_to_ifc
+step_parity = _cad.step_parity
 glb_diff = _cad.glb_diff
 stream_step_to_glb_st = _cad.stream_step_to_glb_st
 stream_step_to_ngeom = _cad.stream_step_to_ngeom
@@ -139,6 +140,7 @@ __all__ = [
     "glb_diff",
     "stream_step_to_glb_st",
     "stream_step_to_ngeom",
+    "step_parity",
     "StepRootMeta",
     "StepNgeomStream",
     "meshopt_simplify_mesh",

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -382,7 +382,7 @@ Mesh tessellate_box_impl(float dx, float dy, float dz) {
 // to its own instance id). pipeline: "libtess2" (OCC-free neutral path) | "occ" | "cgal"
 // | "hybrid" (ifcopenshell taxonomy kernels). angular is in DEGREES.
 Mesh tessellate_stream_impl(nb::bytes buffer, const std::string &pipeline, double deflection, double angular_deg,
-                            nb::dict settings) {
+                            nb::dict settings, int threads) {
     using namespace adacpp::ngeom;
     NgeomDoc doc;
     try {
@@ -403,6 +403,7 @@ Mesh tessellate_stream_impl(nb::bytes buffer, const std::string &pipeline, doubl
         TessParams tp;
         tp.deflection = deflection;
         tp.max_angle = angular_deg * 3.14159265358979323846 / 180.0;
+        tp.threads = threads;  // >1 => parallelise a root's faces (opt-in; default serial)
         tm = tessellate_doc(doc, tp);
     } else {
         // taxonomy kernels; accept "occ"/"cgal"/"hybrid" or "taxonomy-<k>"
@@ -3584,7 +3585,7 @@ void cad_module(nb::module_ &m) {
           "buffer. linear_deflection<=0 selects a per-shape bbox heuristic.");
 
     m.def("tessellate_stream", &tessellate_stream_impl, "buffer"_a, "pipeline"_a = "libtess2", "deflection"_a = 0.0,
-          "angular_deg"_a = 20.0, "settings"_a = nb::dict(),
+          "angular_deg"_a = 20.0, "settings"_a = nb::dict(), "threads"_a = 1,
           "Decode an NGEOM stream buffer (adapy ada.geom, neutral schema) and tessellate "
           "every instance into ONE combined Mesh with a GroupReference per root "
           "(node_id = root index). pipeline: 'libtess2' (OCC-free) | 'occ' | 'cgal' | "

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -3218,6 +3218,152 @@ static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_pa
     return fs;
 }
 
+// Cross-format parity in ONE native parse: resolve every root a single time and run BOTH the
+// STEP->IFC and STEP->STEP emitters over it, tallying each format's losslessness (solids/faces
+// in-vs-out + drop reasons + placed-instance count) WITHOUT writing any output file. This is the
+// fan-out of the two write_*_file_impl above: they each re-parse + re-resolve the whole model and
+// serialise multi-GB output just so the parity check can count it; here the expensive per-solid
+// resolve_root is shared and nothing is serialised to disk. Bounded memory (one resolved solid +
+// a per-solid throwaway buffer per worker), parallel across roots.
+struct ParityFormat {
+    long solids_out = 0; // roots that emitted at least one solid in this format
+    long instances = 0;  // placed occurrences written (proxies / baked parts) — the parity metric
+    adacpp::ifc_emit::EmitStats geom;
+    void merge(const ParityFormat &o) {
+        solids_out += o.solids_out;
+        instances += o.instances;
+        geom.faces_in += o.geom.faces_in;
+        geom.faces_out += o.geom.faces_out;
+        geom.faces_dropped += o.geom.faces_dropped;
+        geom.edges_analytic += o.geom.edges_analytic;
+        geom.edges_polyline_approx += o.geom.edges_polyline_approx;
+        geom.edges_degenerate += o.geom.edges_degenerate;
+        for (const auto &[k, v] : o.geom.drop_reasons)
+            geom.drop_reasons[k] += v;
+    }
+};
+
+static void accum_geom(adacpp::ifc_emit::EmitStats &dst, const adacpp::ifc_emit::EmitStats &s) {
+    dst.faces_in += s.faces_in;
+    dst.faces_out += s.faces_out;
+    dst.faces_dropped += s.faces_dropped;
+    dst.edges_analytic += s.edges_analytic;
+    dst.edges_polyline_approx += s.edges_polyline_approx;
+    dst.edges_degenerate += s.edges_degenerate;
+    for (const auto &[k, v] : s.drop_reasons)
+        dst.drop_reasons[k] += v;
+}
+
+static void step_parity_impl(const std::string &in_path, double deflection, double angular_deg, int num_threads,
+                             long max_solids, long &solids_in_out, long &total_instances_out, double &unit_scale_out,
+                             ParityFormat &ifc_out, ParityFormat &step_out) {
+    using adacpp::ngeom::NgeomRoot;
+    using adacpp::step_emit::StepBrepEmitter;
+    using namespace adacpp::ifc_emit;
+    auto idx = adacpp::step::StreamIndex::from_file(in_path);
+    adacpp::step::Resolver master(idx);
+    master.build_metadata(idx.lists);
+    unit_scale_out = master.unit_scale();
+    std::vector<long> roots(idx.lists.roots.begin(), idx.lists.roots.end());
+    if (max_solids > 0 && (long) roots.size() > max_solids)
+        roots.resize(max_solids);
+    {
+        std::vector<std::pair<size_t, long>> cost;
+        cost.reserve(roots.size());
+        for (long sid : roots)
+            cost.emplace_back(master.solid_face_count(sid), sid);
+        master.clear_geom_cache();
+        std::sort(cost.begin(), cost.end(), [](const auto &a, const auto &b) { return a.first > b.first; });
+        for (size_t i = 0; i < cost.size(); ++i)
+            roots[i] = cost[i].second;
+    }
+    unsigned hw = std::thread::hardware_concurrency();
+    int nth = num_threads > 0 ? num_threads : (int) (hw > 1 ? hw : 1);
+    if (nth > (int) roots.size())
+        nth = std::max(1, (int) roots.size());
+    std::vector<ParityFormat> ifc_lanes(nth), step_lanes(nth);
+    std::atomic<size_t> next{0};
+    std::atomic<long> solids_in{0};
+    std::atomic<long> total_instances{0}; // every placed occurrence in the source (the parity baseline)
+    auto worker = [&](int t) {
+        adacpp::step::Resolver r(idx);
+        r.copy_metadata_from(master);
+        ParityFormat &LI = ifc_lanes[t];
+        ParityFormat &LS = step_lanes[t];
+        std::string sb; // per-solid throwaway (emitters write here; we only read their stats)
+        int local = 0;
+        for (;;) {
+            size_t i = next.fetch_add(1, std::memory_order_relaxed);
+            if (i >= roots.size())
+                break;
+            NgeomRoot root = r.resolve_root(roots[i]); // the shared parse — resolved ONCE, both formats
+            solids_in.fetch_add(1, std::memory_order_relaxed);
+            total_instances.fetch_add((long) (root.transforms.empty() ? 1 : root.transforms.size()),
+                                      std::memory_order_relaxed);
+
+            // ── IFC: geometry once + one proxy per instance (IfcMappedItem) ──
+            sb.clear();
+            BrepEmitter emi(17, nullptr, deflection, angular_deg);
+            std::vector<long> proxies;
+            emit_solid_ifc(emi, sb, root, roots[i], (uint64_t) i * 1000u, proxies, nullptr);
+            if (!proxies.empty())
+                ++LI.solids_out;
+            LI.instances += (long) proxies.size();
+            accum_geom(LI.geom, emi.stats());
+
+            // ── STEP: one baked part per instance (matches write_step_file_impl) ──
+            size_t ninst = root.transforms.empty() ? 1 : root.transforms.size();
+            bool any = false;
+            for (size_t k = 0; k < ninst; ++k) {
+                double tf[16];
+                const double *tfp = nullptr;
+                if (!root.transforms.empty()) {
+                    const std::array<float, 16> &M = root.transforms[k];
+                    tf[0] = M[0];
+                    tf[1] = M[4];
+                    tf[2] = M[8];
+                    tf[3] = M[12];
+                    tf[4] = M[1];
+                    tf[5] = M[5];
+                    tf[6] = M[9];
+                    tf[7] = M[13];
+                    tf[8] = M[2];
+                    tf[9] = M[6];
+                    tf[10] = M[10];
+                    tf[11] = M[14];
+                    tfp = tf;
+                }
+                sb.clear();
+                StepBrepEmitter ems(13, tfp, deflection, angular_deg);
+                if (emit_solid_step(ems, sb, root, roots[i])) {
+                    any = true;
+                    ++LS.instances;
+                    accum_geom(LS.geom, ems.stats());
+                }
+            }
+            if (any)
+                ++LS.solids_out;
+
+            r.clear_geom_cache();
+            if (++local % 128 == 0)
+                adacpp::mem_trim();
+        }
+    };
+    std::vector<std::thread> pool;
+    pool.reserve(nth - 1);
+    for (int t = 1; t < nth; ++t)
+        pool.emplace_back(worker, t);
+    worker(0);
+    for (std::thread &th : pool)
+        th.join();
+    for (int t = 0; t < nth; ++t) {
+        ifc_out.merge(ifc_lanes[t]);
+        step_out.merge(step_lanes[t]);
+    }
+    solids_in_out = solids_in.load();
+    total_instances_out = total_instances.load();
+}
+
 // Native IFC->STEP (AP242): IfcResolver reads each product's analytic B-rep -> ng::, then the STEP
 // emitter re-writes it (instances baked). Serial (per-product resolve is cheap; the shared
 // IfcRepresentationMap brep is re-resolved per instance = baked). Round-trip with the STEP->IFC writer.
@@ -3512,6 +3658,45 @@ void cad_module(nb::module_ &m) {
         "num_threads"_a = 0,
         "Native parallel STEP->STEP (AP242): re-export each solid's analytic B-rep as a "
         "MANIFOLD_SOLID_BREP part (instances baked), no OCC. Returns the losslessness audit dict.");
+
+    // Cross-format parity in ONE parse (the fan-out of stream_step_to_ifc + stream_step_to_step):
+    // resolve each root once, run both emitters, count what each format preserves — no file output.
+    m.def(
+        "step_parity",
+        [](const std::string &in_path, double deflection, double angular_deg, long max_solids,
+           int num_threads) -> nb::dict {
+            long solids_in = 0, total_instances = 0;
+            double unit_scale = 1.0;
+            ParityFormat ifc_fmt, step_fmt;
+            step_parity_impl(in_path, deflection, angular_deg, num_threads, max_solids, solids_in, total_instances,
+                             unit_scale, ifc_fmt, step_fmt);
+            auto fmt_dict = [](const ParityFormat &f) {
+                nb::dict d;
+                d["solids_out"] = f.solids_out;
+                d["instances"] = f.instances;
+                d["faces_in"] = f.geom.faces_in;
+                d["faces_out"] = f.geom.faces_out;
+                d["faces_dropped"] = f.geom.faces_dropped;
+                nb::dict reasons;
+                for (const auto &[k, v] : f.geom.drop_reasons)
+                    reasons[k.c_str()] = v;
+                d["drop_reasons"] = reasons;
+                return d;
+            };
+            nb::dict d;
+            d["solids_in"] = solids_in;
+            d["total_instances"] = total_instances; // source placed-instance count == the parity baseline
+            d["unit_scale"] = unit_scale;
+            d["ifc"] = fmt_dict(ifc_fmt);
+            d["step"] = fmt_dict(step_fmt);
+            return d;
+        },
+        "in_path"_a, "deflection"_a = 2.0, "angular_deg"_a = 20.0, "max_solids"_a = 0, "num_threads"_a = 0,
+        "Cross-format STEP parity in a single native parse: resolve every root once and run both the "
+        "STEP->IFC and STEP->STEP emitters over it, returning {solids_in, unit_scale, ifc:{...}, step:{...}} "
+        "where each format dict is {solids_out, instances, faces_in, faces_out, faces_dropped, drop_reasons}. "
+        "No output file is written — the fan-out of stream_step_to_ifc + stream_step_to_step for the parity "
+        "check, so the expensive per-solid resolve is shared and nothing is serialised to disk.");
 
     // Native IFC->STEP (AP242): read an IFC advanced-B-rep file -> ng:: -> STEP, no OCC.
     m.def(

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -87,6 +87,8 @@
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <ShapeFix_Face.hxx>
 #include <ShapeFix_Shape.hxx>
+#include <GeomAPI_ProjectPointOnSurf.hxx>
+#include <Geom2dAPI_ProjectPointOnCurve.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_BSplineSurface.hxx>
 #include <Geom_SurfaceOfRevolution.hxx>
@@ -1722,9 +1724,19 @@ Handle(Geom_BSplineSurface) make_bspline_surface(int u_degree, int v_degree,
 
 // Build a face edge from a 2D pcurve record (kind 6) laid on `surf`:
 //   [6, degree, rational, closed, n_poles, <2*n_poles uv>, n_knots, <knots>,
-//    <mults>, <n_poles weights if rational>]
+//    <mults>, <n_poles weights if rational>,
+//    <optional tail: 1, t0, t1  |  2, t0, t1, sx, sy, sz, ex, ey, ez>]
 // The 3D parametrization is derived by OCCT from surface(pcurve(t)), so 2D/3D
 // stay consistent — the SAT-pcurve path adapy's make_face_from_geom prefers.
+// The optional tail is the owning edge's trim. SAT pcurves typically span the
+// FULL underlying curve, so without a trim the edge overshoots its segment and
+// the boundary wire fails to connect. Preferred trim (flag 2): the edge's
+// declared 3D vertices, projected point -> surface UV -> pcurve param — exact
+// regardless of parameterization. Fallback (flag 1 or failed projection): the
+// edge's curve-params, tried directly and negated (per the ACIS SAT spec a
+// reversed-sense edge stores its params as (-b, -a) of the true range [a, b]);
+// note an ACIS bs2 pcurve is a fit approximation with its own parameterization,
+// so curve-params can land slightly off (cm-scale) — hence the projection path.
 TopoDS_Edge edge_from_pcurve(const std::vector<double> &e, const Handle(Geom_Surface) & surf) {
     const int degree = static_cast<int>(std::lround(e[1]));
     const bool rational = std::lround(e[2]) != 0;
@@ -1752,7 +1764,49 @@ TopoDS_Edge edge_from_pcurve(const std::vector<double> &e, const Handle(Geom_Sur
     } else {
         c2d = new Geom2d_BSplineCurve(poles, knots, mults, degree, closed);
     }
-    return BRepBuilderAPI_MakeEdge(c2d, surf, c2d->FirstParameter(), c2d->LastParameter()).Edge();
+    const double cf = c2d->FirstParameter(), cl = c2d->LastParameter();
+    double lo = cf, hi = cl;
+    bool trimmed = false;
+    const std::size_t tail = e.size() - i;
+    const int flag = tail >= 3 ? static_cast<int>(std::lround(e[i])) : 0;
+
+    if (flag == 2 && tail >= 9) {
+        // Geometric trim: declared 3D vertex -> surface UV -> pcurve param.
+        const gp_Pnt ps(e[i + 3], e[i + 4], e[i + 5]), pe(e[i + 6], e[i + 7], e[i + 8]);
+        try {
+            GeomAPI_ProjectPointOnSurf prj_s(ps, surf), prj_e(pe, surf);
+            if (prj_s.NbPoints() > 0 && prj_e.NbPoints() > 0) {
+                Standard_Real us, vs, ue, ve;
+                prj_s.LowerDistanceParameters(us, vs);
+                prj_e.LowerDistanceParameters(ue, ve);
+                Geom2dAPI_ProjectPointOnCurve p2s(gp_Pnt2d(us, vs), c2d), p2e(gp_Pnt2d(ue, ve), c2d);
+                if (p2s.NbPoints() > 0 && p2e.NbPoints() > 0) {
+                    const double ta = p2s.LowerDistanceParameter(), tb = p2e.LowerDistanceParameter();
+                    lo = std::max(std::min(ta, tb), cf);
+                    hi = std::min(std::max(ta, tb), cl);
+                    trimmed = hi - lo > 1e-12;
+                }
+            }
+        } catch (const Standard_Failure &) {
+            // projection failed — fall through to the param-range trim below
+        }
+    }
+    if (!trimmed && flag >= 1) {
+        const double t0 = e[i + 1], t1 = e[i + 2];
+        const double a = std::min(t0, t1), b = std::max(t0, t1);
+        const double tolp = 1e-9 + 1e-6 * (cl - cf);
+        if (a >= cf - tolp && b <= cl + tolp) {
+            lo = std::max(a, cf);
+            hi = std::min(b, cl);
+        } else if (-b >= cf - tolp && -a <= cl + tolp) { // ACIS reversed-sense edge: params negated
+            lo = std::max(-b, cf);
+            hi = std::min(-a, cl);
+        } else {
+            lo = cf; // trim doesn't map into this pcurve's range — keep the full range
+            hi = cl;
+        }
+    }
+    return BRepBuilderAPI_MakeEdge(c2d, surf, lo, hi).Edge();
 }
 
 ShapeHandle build_bspline_surface_face_impl(int u_degree, int v_degree,

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -54,6 +54,7 @@
 
 #include "posix_compat.h"
 #include "mem_trim.h"
+#include "effective_concurrency.h"
 
 #include <Bnd_Box.hxx>
 #include <Bnd_OBB.hxx>
@@ -2865,8 +2866,7 @@ static adacpp::ifc_emit::FileStats write_ifc_file_parallel_impl(const std::strin
     // No STRIDE guessing, no overflow, compact ids — correct regardless of per-face entity counts.
     std::atomic<long> id_counter{K + 1};
 
-    unsigned hw = std::thread::hardware_concurrency();
-    int nth = num_threads > 0 ? num_threads : (int) (hw > 1 ? hw : 1);
+    int nth = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
     if (nth > (int) roots.size())
         nth = std::max(1, (int) roots.size());
 
@@ -3100,8 +3100,7 @@ static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_pa
     }
     const long K = 13;
     std::atomic<long> id_counter{K + 1};
-    unsigned hw = std::thread::hardware_concurrency();
-    int nth = num_threads > 0 ? num_threads : (int) (hw > 1 ? hw : 1);
+    int nth = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
     if (nth > (int) roots.size())
         nth = std::max(1, (int) roots.size());
     char tmpl[] = "/tmp/adacpp_stp_XXXXXX";
@@ -3294,8 +3293,7 @@ static void step_parity_impl(const std::string &in_path, double deflection, doub
         for (size_t i = 0; i < cost.size(); ++i)
             roots[i] = cost[i].second;
     }
-    unsigned hw = std::thread::hardware_concurrency();
-    int nth = num_threads > 0 ? num_threads : (int) (hw > 1 ? hw : 1);
+    int nth = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
     if (nth > (int) roots.size())
         nth = std::max(1, (int) roots.size());
     std::vector<ParityFormat> ifc_lanes(nth), step_lanes(nth);
@@ -3756,7 +3754,8 @@ void cad_module(nb::module_ &m) {
           "angular_deg"_a = 20.0, "num_threads"_a = 0, "meshopt"_a = true,
           "Native STEP -> GLB file: stream the .stp with the native reader (offset index + per-statement "
           "pread, bounded memory), tessellate each solid across num_threads worker threads (0 = auto = "
-          "hardware_concurrency), each owning a spill lane joined at the end, bake world transform(s) + "
+          "hardware_concurrency clamped to the cgroup cpu quota), each owning a spill lane joined at the "
+          "end, bake world transform(s) + "
           "colour, and write a merge-by-colour GLB matching the adapy viewer's structure. meshopt=true "
           "(default) bakes EXT_meshopt_compression inline (no Python re-pack). Returns the number of "
           "solids written (-1 on I/O error). angular_deg in degrees.");

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -41,6 +41,7 @@
 #include <cstdint>
 #include <deque>
 #include <tuple>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -1152,17 +1153,37 @@ std::vector<std::array<double, 3>> vertex_points_impl(const ShapeHandle &sh) {
 // faces are b-spline AdvancedFaces that don't bound a volume. Returns whatever
 // the sewer yields (a shell, or a compound of shells/faces if disjoint).
 ShapeHandle sew_faces_impl(const std::vector<ShapeHandle> &faces, double tolerance) {
+    // BRepBuilderAPI_Sewing's candidate matching is quadratic in the number of
+    // free edges, with per-candidate B-spline curve evaluation — a single-body
+    // shell of ~5k spline faces (SESAM hull skin) takes >10 min single-threaded.
+    // Sewing only stitches shared edges (connectivity); tessellation, entity
+    // counting and B-rep export all work face-per-face. Above the cap, return a
+    // plain compound of the faces instead of sewing. ADACPP_SEW_MAX_FACES overrides.
+    size_t sew_max = 1000;
+    if (const char *env = std::getenv("ADACPP_SEW_MAX_FACES"))
+        sew_max = (size_t) std::strtoul(env, nullptr, 10);
+    size_t n_valid = 0;
+    for (const auto &f : faces)
+        if (!f.topods().IsNull())
+            ++n_valid;
+    if (n_valid == 0)
+        throw std::runtime_error("sew_faces: no faces");
+    if (n_valid > sew_max) {
+        TopoDS_Compound comp;
+        BRep_Builder builder;
+        builder.MakeCompound(comp);
+        for (const auto &f : faces)
+            if (!f.topods().IsNull())
+                builder.Add(comp, f.topods());
+        return ShapeHandle(comp);
+    }
     BRepBuilderAPI_Sewing sewer(tolerance > 0.0 ? tolerance : 1e-6);
-    int added = 0;
     for (const auto &f : faces) {
         const TopoDS_Shape s = f.topods();
         if (s.IsNull())
             continue;
         sewer.Add(s);
-        ++added;
     }
-    if (added == 0)
-        throw std::runtime_error("sew_faces: no faces");
     sewer.Perform();
     const TopoDS_Shape sewn = sewer.SewedShape();
     if (sewn.IsNull())

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -1852,10 +1852,21 @@ static ShapeHandle bounds_trimmed_analytic_face(const Handle(Geom_Surface) & sur
     if (bounds.empty())
         throw std::runtime_error(std::string(who) + ": no bounds");
 
+    // A kind-6 record is a 2D pcurve laid on `surf` (3D derived as surface(pcurve(t))) — this is
+    // how a boundary whose edges do NOT lie on the surface (a cylinder trimmed by a diagonal
+    // joint cut, whose edges are chords/helices) is put ON the surface so BRepMesh tessellates it
+    // curved; without pcurves such a face meshed flat/degenerate. Mirrors build_advanced_face_bspline.
+    bool has_pcurve = false;
     auto wire_of = [&](const std::vector<std::vector<double>> &edges) -> TopoDS_Wire {
         BRepBuilderAPI_MakeWire wm;
-        for (const auto &rec : edges)
-            wm.Add(edge_from_record(rec));
+        for (const auto &rec : edges) {
+            if (!rec.empty() && std::lround(rec[0]) == 6) {
+                wm.Add(edge_from_pcurve(rec, surf));
+                has_pcurve = true;
+            } else {
+                wm.Add(edge_from_record(rec));
+            }
+        }
         wm.Build();
         if (!wm.IsDone())
             throw std::runtime_error(std::string(who) + ": wire build failed");
@@ -1868,6 +1879,11 @@ static ShapeHandle bounds_trimmed_analytic_face(const Handle(Geom_Surface) & sur
     if (!fm.IsDone())
         throw std::runtime_error(std::string(who) + ": MakeFace failed");
     TopoDS_Face face = fm.Face();
+
+    // pcurve-built edges carry no 3D curve yet — materialise them from surface(pcurve(t)) so
+    // sewing/tessellation have real 3D geometry (mirrors the B-spline face path).
+    if (has_pcurve)
+        BRepLib::BuildCurves3d(face);
 
     ShapeFix_Face fixer(face);
     fixer.Perform();

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -3018,6 +3018,8 @@ static adacpp::ifc_emit::FileStats write_ifc_file_parallel_impl(const std::strin
                 adacpp::mem_trim();
             flush(false);
         }
+        if (r.degenerate_faces_skipped_ > 0)
+            L.stats.drop_reasons["face:degenerate-skipped(read)"] += r.degenerate_faces_skipped_;
         flush(true);
         std::fclose(L.fp);
         L.fp = nullptr;
@@ -3264,6 +3266,8 @@ static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_pa
                 adacpp::mem_trim();
             flush(false);
         }
+        if (r.degenerate_faces_skipped_ > 0)
+            L.stats.drop_reasons["face:degenerate-skipped(read)"] += r.degenerate_faces_skipped_;
         flush(true);
         std::fclose(L.fp);
         L.fp = nullptr;
@@ -3437,6 +3441,12 @@ static void step_parity_impl(const std::string &in_path, double deflection, doub
             r.clear_geom_cache();
             if (++local % 128 == 0)
                 adacpp::mem_trim();
+        }
+        // Read-side skips (zero-area `$`-surface faces) — informational, not a
+        // faces_dropped leg: the face carries no geometry in the source.
+        if (r.degenerate_faces_skipped_ > 0) {
+            LI.geom.drop_reasons["face:degenerate-skipped(read)"] += r.degenerate_faces_skipped_;
+            LS.geom.drop_reasons["face:degenerate-skipped(read)"] += r.degenerate_faces_skipped_;
         }
     };
     std::vector<std::thread> pool;

--- a/src/cad/effective_concurrency.h
+++ b/src/cad/effective_concurrency.h
@@ -1,0 +1,95 @@
+#pragma once
+// Container-aware auto thread count. Inside a container with a CFS cpu quota,
+// std::thread::hardware_concurrency() reports the NODE's cores (a k8s pod with
+// cpu=4 on a 16-core node sees 16) — the quota throttles time slices, it doesn't
+// mask cores. Sizing a solid-resolve pool from the node count both oversubscribes
+// the quota AND multiplies peak RSS by the extra threads, since each thread holds
+// a whole resolved solid (and the pools sort largest-first, so the N biggest
+// solids are resolved concurrently at the start). Clamp the auto count to the
+// cgroup quota when one is set; explicit num_threads arguments stay untouched.
+// No cgroup files (macOS / Windows / wasm) -> plain hardware_concurrency().
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <thread>
+
+namespace adacpp {
+
+namespace detail {
+
+// Parse "<quota_us>|max <period_us>" (cgroup v2 cpu.max). 0 = no quota.
+inline unsigned parse_cpu_max(const char *path) {
+    std::FILE *f = std::fopen(path, "r");
+    if (!f)
+        return 0;
+    double quota = 0, period = 0;
+    int n = std::fscanf(f, "%lf %lf", &quota, &period); // "max" fails the first %lf -> n < 2
+    std::fclose(f);
+    if (n == 2 && quota > 0 && period > 0)
+        return (unsigned) ((quota + period - 1) / period); // ceil: cpu=3.5 -> 4 threads
+    return 0;
+}
+
+// The process's cgroup-v2 relative path from /proc/self/cgroup ("0::<path>").
+inline std::string self_cgroup_v2_path() {
+    std::FILE *f = std::fopen("/proc/self/cgroup", "r");
+    if (!f)
+        return {};
+    char line[512];
+    std::string out;
+    while (std::fgets(line, sizeof(line), f)) {
+        if (std::strncmp(line, "0::", 3) == 0) {
+            out.assign(line + 3);
+            while (!out.empty() && (out.back() == '\n' || out.back() == '/'))
+                out.pop_back();
+            break;
+        }
+    }
+    std::fclose(f);
+    return out;
+}
+
+} // namespace detail
+
+inline unsigned cgroup_cpu_quota() {
+    // cgroup v2: the limit can sit on the process's own cgroup or any ancestor
+    // (k8s sets it on the container scope; with a cgroup namespace that IS
+    // /sys/fs/cgroup, on a plain host it's a nested systemd scope/slice).
+    // Walk from the process's cgroup up to the root; nearest quota wins.
+    std::string rel = detail::self_cgroup_v2_path();
+    for (;;) {
+        std::string p = "/sys/fs/cgroup" + rel + "/cpu.max";
+        if (unsigned q = detail::parse_cpu_max(p.c_str()))
+            return q;
+        if (rel.empty())
+            break;
+        size_t cut = rel.rfind('/');
+        rel = (cut == std::string::npos) ? std::string() : rel.substr(0, cut);
+    }
+    // cgroup v1 (container runtimes mount the container's cgroup at the controller root)
+    long quota = -1, period = -1;
+    if (std::FILE *f = std::fopen("/sys/fs/cgroup/cpu/cpu.cfs_quota_us", "r")) {
+        if (std::fscanf(f, "%ld", &quota) != 1)
+            quota = -1;
+        std::fclose(f);
+    }
+    if (std::FILE *f = std::fopen("/sys/fs/cgroup/cpu/cpu.cfs_period_us", "r")) {
+        if (std::fscanf(f, "%ld", &period) != 1)
+            period = -1;
+        std::fclose(f);
+    }
+    if (quota > 0 && period > 0)
+        return (unsigned) ((quota + period - 1) / period);
+    return 0; // no quota detected
+}
+
+inline unsigned effective_concurrency() {
+    unsigned hw = std::thread::hardware_concurrency();
+    if (hw < 1)
+        hw = 1;
+    unsigned q = cgroup_cpu_quota();
+    return (q > 0 && q < hw) ? q : hw;
+}
+
+} // namespace adacpp

--- a/src/cad/step_to_glb_stream.h
+++ b/src/cad/step_to_glb_stream.h
@@ -3,7 +3,8 @@
 // the nanobind Python binding AND the standalone STP2GLB CLI without dragging in OCCT or nanobind.
 //
 // Stream the .stp with the native reader (offset index + per-statement pread, bounded memory),
-// tessellate each solid across `num_threads` worker threads (0 = auto = hardware_concurrency), bake
+// tessellate each solid across `num_threads` worker threads (0 = auto = hardware_concurrency clamped
+// to the cgroup cpu quota, see effective_concurrency.h), bake
 // each placement's world transform + colour, and write a merge-by-colour GLB matching the adapy
 // viewer's structure. `meshopt=true` bakes EXT_meshopt_compression inline. Returns the number of
 // solids written, or -1 on I/O error.
@@ -22,6 +23,7 @@
 #include <vector>
 
 #include "mem_trim.h"
+#include "effective_concurrency.h"
 #include "posix_compat.h"
 
 #include "../cadit/step/step_reader.h"
@@ -58,8 +60,7 @@ inline long stream_step_to_glb(const std::string &in_path, const std::string &ou
     master.build_metadata(idx.lists);
     prof.phase("metadata");
 
-    unsigned hw = std::thread::hardware_concurrency();
-    int nthreads = num_threads > 0 ? num_threads : (int) (hw > 1 ? hw : 1);
+    int nthreads = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
 
     // LPT scheduling: order roots heaviest-first (by a cheap face-count proxy, no geometry built) so
     // the big solids start while every thread is still busy — the dynamic queue then fills the tail

--- a/src/cad/step_to_mesh_stream.h
+++ b/src/cad/step_to_mesh_stream.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "mem_trim.h"
+#include "effective_concurrency.h"
 #include "posix_compat.h"
 
 #include "../cadit/step/step_reader.h"
@@ -174,8 +175,7 @@ inline long stream_step_to_mesh(const std::string &in_path, const std::string &o
     master.build_metadata(idx.lists);
     prof.phase("metadata");
 
-    unsigned hw = std::thread::hardware_concurrency();
-    int nthreads = num_threads > 0 ? num_threads : (int) (hw > 1 ? hw : 1);
+    int nthreads = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
 
     // LPT: heaviest solids first so big ones start while every thread is busy.
     std::vector<long> roots(idx.lists.roots.begin(), idx.lists.roots.end());

--- a/src/cadit/step/step_reader.h
+++ b/src/cadit/step/step_reader.h
@@ -808,6 +808,12 @@ private:
     std::unordered_map<long, std::shared_ptr<ng::Curve>> curve_cache_;
     std::unordered_map<long, std::shared_ptr<ng::FaceSurfaceN>> face_cache_;
 
+public:
+    // Zero-area faces with a `$` surface skipped at read time (see face()).
+    long degenerate_faces_skipped_ = 0;
+
+private:
+
     struct RGBA {
         float r, g, b, a;
     };
@@ -1267,7 +1273,37 @@ private:
         return b;
     }
 
+    // Best-effort plane through a loop's sampled points (Newell). Null when the
+    // loop is zero-area — e.g. two collinear LINE edges between the same two
+    // vertices, a sliver face some exporters emit with a `$` surface.
+    std::shared_ptr<ng::Surface> plane_from_loop(const ng::LoopN &lp) {
+        std::vector<ng::Vec3> pts = lp.discretize(1e-2, 0.5);
+        if (pts.size() >= 2 && (pts.front() - pts.back()).norm() < 1e-9)
+            pts.pop_back();
+        if (pts.size() < 3)
+            return nullptr;
+        ng::Vec3 c{0, 0, 0};
+        for (const ng::Vec3 &p : pts)
+            c = c + p;
+        c = c * (1.0 / double(pts.size()));
+        ng::Vec3 n{0, 0, 0};
+        double perimeter = 0;
+        for (size_t i = 0; i < pts.size(); ++i) {
+            ng::Vec3 a = pts[i] - c, b = pts[(i + 1) % pts.size()] - c;
+            n = n + a.cross(b);
+            perimeter += (b - a).norm();
+        }
+        // |n| = 2*area; degenerate when the loop's area vanishes vs its extent.
+        if (perimeter <= 0 || n.norm() <= 1e-9 * perimeter * perimeter)
+            return nullptr;
+        return std::make_shared<ng::PlaneSurface>(ng::Frame::from_axis_ref(c, n, ng::Vec3{0, 0, 0}));
+    }
+
     // ADVANCED_FACE / FACE_SURFACE('',(#bound,...),#surface,same_sense).
+    // A face whose surface is `$` (unset) gets a plane fitted through its outer
+    // loop when the loop has area; a zero-area loop means the face carries no
+    // geometry at all -> returns null and the shell skips it (what OCC's
+    // ShapeFix does on import), instead of an ERR-ing surface:null drop later.
     std::shared_ptr<ng::FaceSurfaceN> face(long id) {
         auto c = face_cache_.find(id);
         if (c != face_cache_.end())
@@ -1282,6 +1318,14 @@ private:
             if (in->args[2].is_ref())
                 f->surface = surface(in->args[2].i);
             f->same_sense = enum_true(in->args[3]);
+            if (!f->surface && !f->bounds.empty() && f->bounds[0].loop) {
+                f->surface = plane_from_loop(*f->bounds[0].loop);
+                if (!f->surface) {
+                    ++degenerate_faces_skipped_;
+                    face_cache_[id] = nullptr;
+                    return nullptr;
+                }
+            }
         }
         face_cache_[id] = f;
         return f;
@@ -1305,7 +1349,8 @@ private:
                 // Default (incl. the multi-threaded mesh/glb path): unchanged.
                 for (const Value &fr : in->args[1].items)
                     if (fr.is_ref())
-                        out.push_back(face(fr.i));
+                        if (auto fp = face(fr.i))
+                            out.push_back(fp);
                 return;
             }
             // Single-threaded bounded path (StepNgeomStream): copy the face refs out first (clearing
@@ -1317,7 +1362,8 @@ private:
                 if (fr.is_ref())
                     face_ids.push_back(fr.i);
             for (size_t i = 0; i < face_ids.size(); ++i) {
-                out.push_back(face(face_ids[i]));
+                if (auto fp = face(face_ids[i]))
+                    out.push_back(fp);
                 if ((i & 1023u) == 1023u)
                     parse_cache_.clear();
             }

--- a/src/cadit/step/step_reader.h
+++ b/src/cadit/step/step_reader.h
@@ -552,7 +552,12 @@ private:
             lists.roots.push_back(id);
         else if (t == "STYLED_ITEM")
             lists.styled.push_back(id);
-        else if (t == "ADVANCED_BREP_SHAPE_REPRESENTATION")
+        else if (t == "ADVANCED_BREP_SHAPE_REPRESENTATION" || t == "SHAPE_REPRESENTATION" ||
+                 t == "MANIFOLD_SURFACE_SHAPE_REPRESENTATION" || t == "FACETED_BREP_SHAPE_REPRESENTATION" ||
+                 t == "GEOMETRICALLY_BOUNDED_SURFACE_SHAPE_REPRESENTATION")
+            // Every rep type that can carry geometry roots — OCC writes shell models under a
+            // plain SHAPE_REPRESENTATION. build_transform_map classifies geometry reps vs
+            // placement reps by whether the items actually contain roots.
             lists.absr.push_back(id);
         else if (t == "SHAPE_REPRESENTATION_RELATIONSHIP")
             lists.srr.push_back(id);
@@ -763,7 +768,9 @@ private:
                 tl.roots.push_back(id);
             else if (t == "STYLED_ITEM")
                 tl.styled.push_back(id);
-            else if (t == "ADVANCED_BREP_SHAPE_REPRESENTATION")
+            else if (t == "ADVANCED_BREP_SHAPE_REPRESENTATION" || t == "SHAPE_REPRESENTATION" ||
+                     t == "MANIFOLD_SURFACE_SHAPE_REPRESENTATION" || t == "FACETED_BREP_SHAPE_REPRESENTATION" ||
+                     t == "GEOMETRICALLY_BOUNDED_SURFACE_SHAPE_REPRESENTATION")
                 tl.absr.push_back(id);
             else if (t == "SHAPE_REPRESENTATION_RELATIONSHIP")
                 tl.srr.push_back(id);
@@ -1700,19 +1707,35 @@ private:
     void build_transform_map(const std::vector<long> &root_ids, const std::vector<long> &absr_ids,
                              const std::vector<long> &srr_ids, const std::vector<long> &cdsr_ids) {
         std::unordered_set<long> root_set(root_ids.begin(), root_ids.end());
-        // ABSR items -> solid (geom rep of each solid); collect the ABSR id set.
+        // Geometry-rep items -> solid. `absr_ids` holds every rep type that can carry
+        // geometry (ABSR, plain SHAPE_REPRESENTATION, ...); a rep counts as a geometry
+        // rep only when its items actually contain a root — a plain SHAPE_REPRESENTATION
+        // holding just axis placements is a placement rep and must stay OUT of the set,
+        // or the SHAPE_REPRESENTATION_RELATIONSHIP side-picking below flips.
+        // Two passes: specific rep types (ABSR & co.) claim their roots first; a plain
+        // SHAPE_REPRESENTATION only maps roots nothing else claimed — an aggregating
+        // root-level SR (AS1's 'design' listing every solid) must not steal a solid
+        // from its own product's rep, or every solid names/paths as the assembly root.
         std::unordered_set<long> absr_set;
         std::unordered_map<long, long> geomrep_of_solid;
-        for (long id : absr_ids) {
-            const Instance *in = inst(id);
-            if (!in || in->complex)
-                continue;
-            absr_set.insert(id);
-            if (in->args.size() < 2 || in->args[1].kind != Kind::List)
-                continue;
-            for (const Value &it : in->args[1].items)
-                if (it.is_ref() && root_set.count(it.i))
-                    geomrep_of_solid[it.i] = id;
+        for (int pass = 0; pass < 2; ++pass) {
+            for (long id : absr_ids) {
+                const Instance *in = inst(id);
+                if (!in || in->complex)
+                    continue;
+                if ((in->type == "SHAPE_REPRESENTATION") != (pass == 1))
+                    continue;
+                if (in->args.size() < 2 || in->args[1].kind != Kind::List)
+                    continue;
+                bool has_root = false;
+                for (const Value &it : in->args[1].items)
+                    if (it.is_ref() && root_set.count(it.i)) {
+                        geomrep_of_solid.emplace(it.i, id);
+                        has_root = true;
+                    }
+                if (has_root)
+                    absr_set.insert(id);
+            }
         }
         // Standalone SHAPE_REPRESENTATION_RELATIONSHIP: the non-ABSR side is the placement rep.
         std::unordered_map<long, long> place_rep_of_geom;

--- a/src/geom/neutral/ngeom_decode.h
+++ b/src/geom/neutral/ngeom_decode.h
@@ -50,6 +50,7 @@ enum : int {
     REVOLVED_AREA_SOLID = 51,
     BOOLEAN_RESULT = 52,
     SPHERE_SOLID = 53,
+    FIXED_REF_SWEPT_SOLID = 54,
     EDGE_CURVE = 60,
     ORIENTED_EDGE = 61,
     EDGE_LOOP = 62,
@@ -151,6 +152,7 @@ struct Slot {
     std::shared_ptr<ConnectedFaceSetN> cfs;
     std::shared_ptr<ExtrusionN> extrusion;
     std::shared_ptr<RevolveN> revolve;
+    std::shared_ptr<SweepN> sweep;
     std::shared_ptr<BooleanN> boolean;
     std::shared_ptr<SphereN> sphere;
     std::shared_ptr<OrientedEdgeN> oedge;
@@ -186,6 +188,8 @@ inline NgeomDoc decode(const uint8_t *data, size_t n) {
             it.extrusion = s.extrusion;
         else if (s.revolve)
             it.revolve = s.revolve;
+        else if (s.sweep)
+            it.sweep = s.sweep;
         else if (s.boolean)
             it.boolean = s.boolean;
         else if (s.cfs)
@@ -470,6 +474,23 @@ inline NgeomDoc decode(const uint8_t *data, size_t n) {
             slot.sphere = sp;
             break;
         }
+        case tag::FIXED_REF_SWEPT_SOLID: {
+            auto sw = std::make_shared<SweepN>();
+            sw->profile = S.at(r.i32()).face; // profile FACE_SURFACE
+            sw->frame = frame_at(r.i32());    // PLACEMENT3 (position)
+            int ns = r.i32();
+            std::vector<double> o = r.f64s(ns * 3), dx = r.f64s(ns * 3), dy = r.f64s(ns * 3);
+            sw->origin.resize(ns);
+            sw->dir_x.resize(ns);
+            sw->dir_y.resize(ns);
+            for (int i = 0; i < ns; ++i) {
+                sw->origin[i] = {o[3 * i], o[3 * i + 1], o[3 * i + 2]};
+                sw->dir_x[i] = {dx[3 * i], dx[3 * i + 1], dx[3 * i + 2]};
+                sw->dir_y[i] = {dy[3 * i], dy[3 * i + 1], dy[3 * i + 2]};
+            }
+            slot.sweep = sw;
+            break;
+        }
         default:
             break; // unknown tag -> skipped via nbytes below
         }
@@ -492,6 +513,8 @@ inline NgeomDoc decode(const uint8_t *data, size_t n) {
             root.extrusion = gs.extrusion;
         } else if (gs.revolve) {
             root.revolve = gs.revolve;
+        } else if (gs.sweep) {
+            root.sweep = gs.sweep;
         } else if (gs.boolean) {
             root.boolean = gs.boolean;
         } else if (gs.sphere) {

--- a/src/geom/neutral/ngeom_glb.h
+++ b/src/geom/neutral/ngeom_glb.h
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <map>
@@ -276,8 +277,9 @@ inline std::array<int, 4> colour_key(const std::array<float, 4> &c) {
 // ATTRIBUTES — then emitted as buffer 0 = compressed data, buffer 1 = fallback (no bytes), bufferViews
 // carrying the EXT extension. Round-trips every buffer; returns false on any encode/verify failure so
 // the caller falls back to the raw writer. Peak memory = all compressed buffers + one material's raw.
-template <class Provider>
-inline bool glb_write_framed_meshopt(const std::string &path, const std::vector<MatHeader> &hdrs, Provider &&provide,
+template <class ProvideIdx, class ProvidePos>
+inline bool glb_write_framed_meshopt(const std::string &path, const std::vector<MatHeader> &hdrs,
+                                     ProvideIdx &&provide_idx, ProvidePos &&provide_pos,
                                      const std::string &scene_extras, const std::string &ada_ext) {
     auto a4 = [](uint32_t n) { return (n + 3u) & ~3u; };
     struct Enc {
@@ -286,6 +288,19 @@ inline bool glb_write_framed_meshopt(const std::string &path, const std::vector<
     std::vector<Enc> enc(hdrs.size());
     uint32_t coff = 0, uoff = 0;
     static const char z[4] = {0, 0, 0, 0};
+    // Per-buffer encode-roundtrip self-check budget. The verify decodes the just-encoded buffer into
+    // a FULL second copy (di/dv) purely to memcmp — which doubles peak RSS on a big single-material
+    // model (Valve Hall STEP->GLB peaked ~3.1 GB, ~1 GB of it these decode copies) and pushed the
+    // capped worker OOM. Verify buffers up to the budget (keeps CI/fixtures + typical models checked);
+    // skip it for the oversized buffers where the copy is the memory problem. ADA_MESHOPT_VERIFY_MAX_BYTES
+    // overrides (0 = never verify, e.g. a memory-pinned worker). Default 256 MiB.
+    size_t verify_max = (size_t) 256u << 20;
+    if (const char *e = std::getenv("ADA_MESHOPT_VERIFY_MAX_BYTES")) {
+        char *end = nullptr;
+        unsigned long long v = std::strtoull(e, &end, 10);
+        if (end != e)
+            verify_max = (size_t) v;
+    }
     // Spill each material's compressed regions to a temp file as we go (one material resident at a
     // time) rather than accumulating every material's compressed buffers — peak memory ~one material.
     std::string tmp = path + ".moptmp";
@@ -295,22 +310,28 @@ inline bool glb_write_framed_meshopt(const std::string &path, const std::vector<
             return false;
         for (size_t i = 0; i < hdrs.size(); ++i) {
             const MatHeader &h = hdrs[i];
-            std::vector<float> pos;
+            // Indices FIRST — load, encode, free — before positions are ever materialised, so a single
+            // large merged material never holds its positions AND indices resident at once. That doubled
+            // peak RSS (Valve Hall STEP->GLB merges to ONE material of ~1.4 GB) and OOM'd the capped
+            // worker. Peak is now max(idx, pos) per material, not their sum.
             std::vector<uint32_t> idx;
-            provide(i, pos, idx);
+            provide_idx(i, idx);
             auto cidx = ::ngeom::meshopt_encode_indices(idx.data(), idx.size(), h.vert_count);
             if (cidx.empty())
                 return false;
-            { // verify + free the index buffer before touching positions
+            // verify (small buffers only — the decode is a full second copy) before freeing indices
+            if ((size_t) idx.size() * 4 <= verify_max) {
                 auto di = ::ngeom::meshopt_decode_indices(cidx.data(), cidx.size(), idx.size(), 4);
                 if (di.size() != idx.size() * 4 || std::memcmp(di.data(), idx.data(), di.size()) != 0)
                     return false;
             }
             std::vector<uint32_t>().swap(idx);
+            std::vector<float> pos;
+            provide_pos(i, pos);
             auto cpos = ::ngeom::meshopt_encode_vertices(pos.data(), h.vert_count, 12);
             if (cpos.empty())
                 return false;
-            {
+            if ((size_t) h.vert_count * 12 <= verify_max) {
                 auto dv = ::ngeom::meshopt_decode_vertices(cpos.data(), cpos.size(), h.vert_count, 12);
                 if (dv.size() != (size_t) h.vert_count * 12 || std::memcmp(dv.data(), pos.data(), dv.size()) != 0)
                     return false;
@@ -480,12 +501,8 @@ inline bool write_glb(const std::string &path, const std::vector<GlbSolid> &soli
         }
     std::string extras = build_scene_extras(per_mat);
     if (meshopt && glb_write_framed_meshopt(
-                       path, hdrs,
-                       [&](size_t i, std::vector<float> &pos, std::vector<uint32_t> &idx) {
-                           pos = bufs[i]->pos;
-                           idx = bufs[i]->idx;
-                       },
-                       extras, ""))
+                       path, hdrs, [&](size_t i, std::vector<uint32_t> &idx) { idx = bufs[i]->idx; },
+                       [&](size_t i, std::vector<float> &pos) { pos = bufs[i]->pos; }, extras, ""))
         return true;
     static const char z[4] = {0, 0, 0, 0};
     return glb_write_framed(path, hdrs, extras, "", [&](std::ofstream &out) {
@@ -648,32 +665,43 @@ inline bool write_glb_merged(const std::string &path, const std::vector<GlbSpill
     // meshopt: read one material at a time from the spill lanes (positions concatenated, indices
     // re-offset by the cumulative vertex base across lanes — exactly the raw merge, into vectors),
     // encode + bake EXT_meshopt_compression. Falls through to the raw writer on any failure.
-    if (meshopt && glb_write_framed_meshopt(
-                       path, hdrs,
-                       [&](size_t mi, std::vector<float> &pos, std::vector<uint32_t> &idx) {
-                           const std::array<int, 4> &key = keys[mi];
-                           uint32_t vbase = 0;
-                           for (GlbSpillWriter *l : lanes) {
-                               auto it = l->mats().find(key);
-                               if (it == l->mats().end())
-                                   continue;
-                               const auto &m = it->second;
-                               size_t nf = (size_t) m.vert_count * 3, old = pos.size();
-                               pos.resize(old + nf);
-                               std::ifstream pf(m.pos_path, std::ios::binary);
-                               pf.read(reinterpret_cast<char *>(pos.data() + old), (std::streamsize) (nf * 4));
-                               std::ifstream xf(m.idx_path, std::ios::binary);
-                               std::vector<uint32_t> rb(1u << 16);
-                               while (xf) {
-                                   xf.read(reinterpret_cast<char *>(rb.data()), (std::streamsize) (rb.size() * 4));
-                                   size_t got = (size_t) (xf.gcount() / 4);
-                                   for (size_t k = 0; k < got; ++k)
-                                       idx.push_back(rb[k] + vbase);
-                               }
-                               vbase += m.vert_count;
-                           }
-                       },
-                       extras, ada_ext))
+    // Two providers (indices, positions) read one attribute at a time from the spill lanes so the
+    // meshopt writer never holds a material's positions AND indices resident together — see the
+    // idx-first ordering in glb_write_framed_meshopt. Indices are re-offset by the cumulative vertex
+    // base across lanes (the raw-merge order); positions are a plain concat.
+    auto provide_idx = [&](size_t mi, std::vector<uint32_t> &idx) {
+        const std::array<int, 4> &key = keys[mi];
+        uint32_t vbase = 0;
+        for (GlbSpillWriter *l : lanes) {
+            auto it = l->mats().find(key);
+            if (it == l->mats().end())
+                continue;
+            const auto &m = it->second;
+            std::ifstream xf(m.idx_path, std::ios::binary);
+            std::vector<uint32_t> rb(1u << 16);
+            while (xf) {
+                xf.read(reinterpret_cast<char *>(rb.data()), (std::streamsize) (rb.size() * 4));
+                size_t got = (size_t) (xf.gcount() / 4);
+                for (size_t k = 0; k < got; ++k)
+                    idx.push_back(rb[k] + vbase);
+            }
+            vbase += m.vert_count;
+        }
+    };
+    auto provide_pos = [&](size_t mi, std::vector<float> &pos) {
+        const std::array<int, 4> &key = keys[mi];
+        for (GlbSpillWriter *l : lanes) {
+            auto it = l->mats().find(key);
+            if (it == l->mats().end())
+                continue;
+            const auto &m = it->second;
+            size_t nf = (size_t) m.vert_count * 3, old = pos.size();
+            pos.resize(old + nf);
+            std::ifstream pf(m.pos_path, std::ios::binary);
+            pf.read(reinterpret_cast<char *>(pos.data() + old), (std::streamsize) (nf * 4));
+        }
+    };
+    if (meshopt && glb_write_framed_meshopt(path, hdrs, provide_idx, provide_pos, extras, ada_ext))
         return true;
     static const char z[4] = {0, 0, 0, 0};
     return glb_write_framed(path, hdrs, extras, ada_ext, [&](std::ofstream &out) {

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -1740,70 +1740,74 @@ void append_mesh(TessMesh &dst, const TessMesh &src) {
 }
 } // namespace
 
+// Tessellate ONE root's geometry into `out` (no group bookkeeping — the caller records ranges).
+static void tessellate_one_root(const NgeomRoot &root, const TessParams &tp, TessMesh &out) {
+    if (root.extrusion) {
+        Mesh m(out);
+        tessellate_extrusion(*root.extrusion, tp, m);
+    } else if (root.revolve) {
+        Mesh m(out);
+        tessellate_revolve(*root.revolve, tp, m);
+    } else if (root.sweep) {
+        Mesh m(out);
+        tessellate_sweep(*root.sweep, tp, m);
+    } else if (root.boolean) {
+        // CSG via Manifold (no-op on wasm until Manifold is wired there).
+        append_mesh(out, tessellate_boolean_item(*root.boolean, tp));
+    } else if (root.sphere) {
+        Mesh m(out);
+        tessellate_sphere(*root.sphere, tp, m);
+    } else {
+        if (FDBG) {
+            size_t nnull = 0;
+            for (const auto &f : root.faces)
+                if (!f)
+                    ++nnull;
+            std::fprintf(stderr, "FDBG ROOT id=%s faces=%zu null=%zu\n", root.id.c_str(), root.faces.size(), nnull);
+        }
+        for (const auto &face : root.faces)
+            if (face)
+                tessellate_face(*face, tp, out);
+    }
+}
+
 TessMesh tessellate_doc(const NgeomDoc &doc, const TessParams &tp) {
     TessMesh mesh;
-    for (const NgeomRoot &root : doc.roots) {
+    const auto &roots = doc.roots;
+    // Opt-in parallelism (tp.threads>1): tessellate ROOTS across a thread pool into per-root local
+    // buffers, merged in root order. Roots are independent (each tessellate_face allocates its own
+    // libtess2 tessellator, no shared state); merging in order makes the output byte-identical to
+    // serial. Per-root parallelism is the right grain for the merge-preview generate, which streams
+    // one root PER PLATE (thousands of roots) so every plate is its own pickable BatchMesh group.
+    // Default (threads=1) keeps the serial path — the STEP->GLB process pool stays serial per call.
+    unsigned want = tp.threads > 1 ? (unsigned) tp.threads : 1u;
+    if (want <= 1 || roots.size() < 2) {
+        for (const NgeomRoot &root : roots) {
+            uint32_t first = (uint32_t) mesh.indices.size();
+            uint32_t vfirst = (uint32_t) (mesh.positions.size() / 3);
+            tessellate_one_root(root, tp, mesh);
+            mesh.groups.push_back({root.id, first, (uint32_t) mesh.indices.size() - first, vfirst,
+                                   (uint32_t) (mesh.positions.size() / 3) - vfirst});
+        }
+        return mesh;
+    }
+    std::vector<TessMesh> locals(roots.size());
+    std::atomic<size_t> next{0};
+    unsigned nthreads = std::min<unsigned>(want, (unsigned) roots.size());
+    std::vector<std::thread> pool;
+    pool.reserve(nthreads);
+    for (unsigned t = 0; t < nthreads; ++t)
+        pool.emplace_back([&]() {
+            for (size_t i = next.fetch_add(1); i < roots.size(); i = next.fetch_add(1))
+                tessellate_one_root(roots[i], tp, locals[i]);
+        });
+    for (std::thread &th : pool)
+        th.join();
+    for (size_t i = 0; i < roots.size(); ++i) {
         uint32_t first = (uint32_t) mesh.indices.size();
         uint32_t vfirst = (uint32_t) (mesh.positions.size() / 3);
-        if (root.extrusion) {
-            Mesh m(mesh);
-            tessellate_extrusion(*root.extrusion, tp, m);
-        } else if (root.revolve) {
-            Mesh m(mesh);
-            tessellate_revolve(*root.revolve, tp, m);
-        } else if (root.sweep) {
-            Mesh m(mesh);
-            tessellate_sweep(*root.sweep, tp, m);
-        } else if (root.boolean) {
-            // CSG via Manifold (no-op on wasm until Manifold is wired there).
-            append_mesh(mesh, tessellate_boolean_item(*root.boolean, tp));
-        } else if (root.sphere) {
-            Mesh m(mesh);
-            tessellate_sphere(*root.sphere, tp, m);
-        } else {
-            if (FDBG) {
-                size_t nnull = 0;
-                for (const auto &f : root.faces)
-                    if (!f)
-                        ++nnull;
-                std::fprintf(stderr, "FDBG ROOT id=%s faces=%zu null=%zu\n", root.id.c_str(), root.faces.size(), nnull);
-            }
-            // Faces are independent (each tessellate_face allocates its own libtess2
-            // tessellator, no shared state), so tessellate them into per-face local buffers
-            // across a thread pool and merge in order. A big single-root shell (a whole
-            // ship's ~7.5k plates) tessellated serially before — the dominant cost.
-            const auto &fs = root.faces;
-            const size_t nf = fs.size();
-            // Opt-in parallelism (tp.threads>1): tessellate this root's faces across a thread
-            // pool. A handful of EXPENSIVE faces (curved B-spline hull panels) is the heavy case,
-            // so there is no face-count threshold — any nf>=2 parallelises. Faces are independent
-            // (each allocates its own libtess2 tessellator, no shared state); results merge in
-            // order so the output is byte-identical to the serial path.
-            unsigned want = tp.threads > 1 ? (unsigned) tp.threads : 1u;
-            if (nf < 2 || want <= 1) {
-                for (const auto &face : fs)
-                    if (face)
-                        tessellate_face(*face, tp, mesh);
-            } else {
-                std::vector<TessMesh> locals(nf);
-                std::atomic<size_t> next{0};
-                unsigned nthreads = std::min<unsigned>(want, (unsigned) nf);
-                std::vector<std::thread> pool;
-                pool.reserve(nthreads);
-                for (unsigned t = 0; t < nthreads; ++t)
-                    pool.emplace_back([&]() {
-                        for (size_t i = next.fetch_add(1); i < nf; i = next.fetch_add(1))
-                            if (fs[i])
-                                tessellate_face(*fs[i], tp, locals[i]);
-                    });
-                for (std::thread &th : pool)
-                    th.join();
-                for (const TessMesh &lm : locals)
-                    if (!lm.positions.empty())
-                        append_mesh(mesh, lm);
-            }
-        }
-        mesh.groups.push_back({root.id, first, (uint32_t) mesh.indices.size() - first, vfirst,
+        append_mesh(mesh, locals[i]);
+        mesh.groups.push_back({roots[i].id, first, (uint32_t) mesh.indices.size() - first, vfirst,
                                (uint32_t) (mesh.positions.size() / 3) - vfirst});
     }
     return mesh;

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -1,6 +1,8 @@
 #include "ngeom_tessellate.h"
 
 #include <algorithm>
+#include <atomic>
+#include <thread>
 #include <array>
 #include <cmath>
 #include <cstdio>
@@ -1766,9 +1768,40 @@ TessMesh tessellate_doc(const NgeomDoc &doc, const TessParams &tp) {
                         ++nnull;
                 std::fprintf(stderr, "FDBG ROOT id=%s faces=%zu null=%zu\n", root.id.c_str(), root.faces.size(), nnull);
             }
-            for (const auto &face : root.faces)
-                if (face)
-                    tessellate_face(*face, tp, mesh);
+            // Faces are independent (each tessellate_face allocates its own libtess2
+            // tessellator, no shared state), so tessellate them into per-face local buffers
+            // across a thread pool and merge in order. A big single-root shell (a whole
+            // ship's ~7.5k plates) tessellated serially before — the dominant cost.
+            const auto &fs = root.faces;
+            const size_t nf = fs.size();
+            // Opt-in parallelism (tp.threads>1): tessellate this root's faces across a thread
+            // pool. A handful of EXPENSIVE faces (curved B-spline hull panels) is the heavy case,
+            // so there is no face-count threshold — any nf>=2 parallelises. Faces are independent
+            // (each allocates its own libtess2 tessellator, no shared state); results merge in
+            // order so the output is byte-identical to the serial path.
+            unsigned want = tp.threads > 1 ? (unsigned) tp.threads : 1u;
+            if (nf < 2 || want <= 1) {
+                for (const auto &face : fs)
+                    if (face)
+                        tessellate_face(*face, tp, mesh);
+            } else {
+                std::vector<TessMesh> locals(nf);
+                std::atomic<size_t> next{0};
+                unsigned nthreads = std::min<unsigned>(want, (unsigned) nf);
+                std::vector<std::thread> pool;
+                pool.reserve(nthreads);
+                for (unsigned t = 0; t < nthreads; ++t)
+                    pool.emplace_back([&]() {
+                        for (size_t i = next.fetch_add(1); i < nf; i = next.fetch_add(1))
+                            if (fs[i])
+                                tessellate_face(*fs[i], tp, locals[i]);
+                    });
+                for (std::thread &th : pool)
+                    th.join();
+                for (const TessMesh &lm : locals)
+                    if (!lm.positions.empty())
+                        append_mesh(mesh, lm);
+            }
         }
         mesh.groups.push_back({root.id, first, (uint32_t) mesh.indices.size() - first, vfirst,
                                (uint32_t) (mesh.positions.size() / 3) - vfirst});

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -365,6 +365,14 @@ void refine_uv(const Surface &s, std::vector<Uv> &verts, std::vector<Tri> &tris,
         pts3[i] = s.point(verts[i][0], verts[i][1]);
     bool check_dev = dynamic_cast<const PlaneSurface *>(&s) == nullptr;
 
+    // deflection <= 0 means "auto": derive a scale-relative chord tolerance from the surface's
+    // characteristic size instead of refining toward zero deviation (dev > 0 splits every curved
+    // edge up to the 300k budget — catastrophic on a large B-spline patch, e.g. a coarse 6x6 cubic
+    // exploding to ~1M tris). Mirrors the auto-guard the primitive builders already use
+    // (tessellate_sphere/cylinder: `defl = tp.deflection > 0 ? tp.deflection : r * 0.01`).
+    if (defl <= 0.0)
+        defl = std::max(s.approx_size() * 0.005, 1e-4);
+
     double approx_area = 0;
     for (const Tri &t : tris) {
         Vec3 a = pts3[t[0]], b = pts3[t[1]], c = pts3[t[2]];

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -1611,6 +1611,66 @@ void tessellate_revolve(const RevolveN &rv, const TessParams &tp, Mesh &mesh) {
     // Cone/Cylinder use full revolutions, so they are not generated here yet.
 }
 
+// FixedReferenceSweptAreaSolid -> sweep the profile along a precomputed field of per-station frames
+// (origin + dir_x/dir_y). Side walls connect consecutive profile rings; the first/last stations get
+// libtess2 end caps (profile triangulated in local UV, with holes). The directrix analytics (Fresnel
+// clothoid + vertical gradient + fixed-reference frame) are evaluated producer-side; no OCC here.
+void tessellate_sweep(const SweepN &sw, const TessParams &tp, Mesh &mesh) {
+    const size_t ns = sw.origin.size();
+    if (!sw.profile || ns < 2)
+        return;
+    const Frame &F = sw.frame;
+
+    // outer boundary ring (local UV) for the walls + all loops for the cap triangulation
+    std::vector<Vec3> ring;
+    std::vector<std::vector<Uv>> loops_uv;
+    for (const FaceBoundN &b : sw.profile->bounds) {
+        if (!b.loop)
+            continue;
+        std::vector<Vec3> r = b.loop->discretize(tp.deflection, tp.max_angle);
+        std::vector<Uv> uv;
+        uv.reserve(r.size());
+        for (const Vec3 &p : r)
+            uv.push_back({p.x, p.y});
+        if (uv.size() >= 3)
+            loops_uv.push_back(std::move(uv));
+        if (ring.empty())
+            ring = std::move(r); // outer loop drives the walls
+    }
+    if (ring.size() > 1 && (ring.front() - ring.back()).norm() < 1e-12)
+        ring.pop_back();
+    const size_t n = ring.size();
+    if (n < 2)
+        return;
+
+    // profile (u,v) at station j -> world point
+    auto P = [&](size_t j, double u, double v) -> Vec3 {
+        Vec3 local = sw.origin[j] + sw.dir_x[j] * u + sw.dir_y[j] * v;
+        return F.to_world(local.x, local.y, local.z);
+    };
+
+    for (size_t j = 0; j + 1 < ns; ++j) {
+        for (size_t i = 0; i < n; ++i) {
+            size_t i2 = (i + 1) % n;
+            Vec3 a = P(j, ring[i].x, ring[i].y), b = P(j, ring[i2].x, ring[i2].y);
+            Vec3 c = P(j + 1, ring[i2].x, ring[i2].y), d = P(j + 1, ring[i].x, ring[i].y);
+            emit_tri(mesh, a, b, c);
+            emit_tri(mesh, a, c, d);
+        }
+    }
+
+    Tess2Out cap = run_tess2(loops_uv, 1.0, 1.0);
+    if (cap.ok) {
+        for (const Tri &t : cap.tris) {
+            const Uv &u0 = cap.verts[t[0]], &u1 = cap.verts[t[1]], &u2 = cap.verts[t[2]];
+            // start cap (station 0) reversed so its normal faces backward along the sweep
+            emit_tri(mesh, P(0, u0[0], u0[1]), P(0, u2[0], u2[1]), P(0, u1[0], u1[1]));
+            // end cap (last station)
+            emit_tri(mesh, P(ns - 1, u0[0], u0[1]), P(ns - 1, u1[0], u1[1]), P(ns - 1, u2[0], u2[1]));
+        }
+    }
+}
+
 // Sphere primitive -> a UV (lat/long) sphere. Segment counts follow the deflection (angle_step),
 // so it honours the requested tolerance; pole quads collapse (emit_tri skips degenerates).
 void tessellate_sphere(const SphereN &sp, const TessParams &tp, Mesh &mesh) {
@@ -1657,6 +1717,9 @@ TessMesh tessellate_solid_item(const SolidItemN &it, const TessParams &tp) {
     } else if (it.revolve) {
         Mesh mesh(m);
         tessellate_revolve(*it.revolve, tp, mesh);
+    } else if (it.sweep) {
+        Mesh mesh(m);
+        tessellate_sweep(*it.sweep, tp, mesh);
     } else {
         for (const auto &f : it.faces)
             if (f)
@@ -1686,6 +1749,9 @@ TessMesh tessellate_doc(const NgeomDoc &doc, const TessParams &tp) {
         } else if (root.revolve) {
             Mesh m(mesh);
             tessellate_revolve(*root.revolve, tp, m);
+        } else if (root.sweep) {
+            Mesh m(mesh);
+            tessellate_sweep(*root.sweep, tp, m);
         } else if (root.boolean) {
             // CSG via Manifold (no-op on wasm until Manifold is wired there).
             append_mesh(mesh, tessellate_boolean_item(*root.boolean, tp));

--- a/src/geom/neutral/ngeom_tessellate.h
+++ b/src/geom/neutral/ngeom_tessellate.h
@@ -18,6 +18,10 @@ namespace adacpp::ngeom {
 struct TessParams {
     double deflection = 0.0; // chord tolerance for boundary discretization (0 => auto)
     double max_angle = 0.35; // ~20 deg, max turn between boundary samples
+    int threads = 1;         // >1 tessellates a root's faces across a thread pool. Default 1
+                             // (serial) so callers already parallelising across roots/solids
+                             // (the STEP->GLB process pool) don't oversubscribe; a single
+                             // whole-model call (merge-preview generate) opts into all cores.
 };
 
 struct TessMesh {

--- a/src/geom/neutral/ngeom_topology.h
+++ b/src/geom/neutral/ngeom_topology.h
@@ -263,12 +263,26 @@ struct RevolveN {
     double angle = 0; // 0 => full revolution
 };
 
+// A fixed-reference swept-area solid (IfcFixedReferenceSweptAreaSolid over an alignment directrix):
+// a planar profile face swept along a precomputed field of per-station frames. A profile point
+// (u, v) at station j maps to the local point `origin[j] + u*dir_x[j] + v*dir_y[j]`, then placed by
+// `frame`. The analytic directrix (line/clothoid/arc + vertical gradient) is evaluated producer-side
+// (adapy) into these frames, so the kernel only rings + caps them (no OCC, no Frenet roll here).
+struct SweepN {
+    std::shared_ptr<FaceSurfaceN> profile; // planar profile face (local UV, z=0)
+    Frame frame;                           // placement of the swept solid
+    std::vector<Vec3> origin;              // per-station directrix point (local)
+    std::vector<Vec3> dir_x;               // per-station profile local-x axis in 3D (fixed-ref "up")
+    std::vector<Vec3> dir_y;               // per-station profile local-y axis in 3D (lateral)
+};
+
 struct BooleanN; // fwd (recursive)
 
 // One operand of a boolean (or a root): any of the supported solids.
 struct SolidItemN {
     std::shared_ptr<ExtrusionN> extrusion;
     std::shared_ptr<RevolveN> revolve;
+    std::shared_ptr<SweepN> sweep;
     std::shared_ptr<BooleanN> boolean;
     std::vector<std::shared_ptr<FaceSurfaceN>> faces; // shell operand
 };
@@ -292,6 +306,7 @@ struct NgeomRoot {
     std::vector<std::shared_ptr<FaceSurfaceN>> faces; // flattened (a CFS expands to its faces)
     std::shared_ptr<ExtrusionN> extrusion;            // set if this root is an extruded solid
     std::shared_ptr<RevolveN> revolve;                // set if this root is a revolved solid
+    std::shared_ptr<SweepN> sweep;                    // set if this root is a fixed-ref swept solid
     std::shared_ptr<BooleanN> boolean;                // set if this root is a boolean result
     std::shared_ptr<SphereN> sphere;                  // set if this root is a sphere primitive
     // Presentation colour (STYLED_ITEM -> COLOUR_RGB), populated by the native STEP reader; the

--- a/src/stp2glb/main.cpp
+++ b/src/stp2glb/main.cpp
@@ -49,8 +49,7 @@ int main(int argc, char *argv[]) {
         ::setenv("ADACPP_STEP_SOLID_TIMING", "1", 1);
     }
 
-    const unsigned hw = std::thread::hardware_concurrency();
-    const int resolved_threads = num_threads > 0 ? num_threads : (int) (hw > 1 ? hw : 1);
+    const int resolved_threads = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
 
     if (!quiet) {
         std::cout << "STP2GLB Converter (OCC-free native streaming)\n";

--- a/tests/ngeom/run.sh
+++ b/tests/ngeom/run.sh
@@ -37,14 +37,15 @@ done
 
 # tessellation-linked suites: libtess2 objects + the tessellator + the boolean stub
 # (ngeom_tessellate.cpp references mesh_boolean; ngeom_boolean.cpp without ADACPP_HAVE_MANIFOLD
-# compiles the no-op stub, so these link OCC/Manifold-free).
+# compiles the no-op stub, so these link OCC/Manifold-free). -pthread: ngeom_tessellate.cpp uses
+# std::thread for opt-in root-parallel tessellation.
 TESS_LINK="src/geom/neutral/ngeom_tessellate.cpp src/geom/neutral/ngeom_boolean.cpp"
-g++ -std=c++20 -O2 -Wall $INC tests/ngeom/test_tessellate.cpp $TESS_LINK "$obj"/*.o -o "$obj/test_tessellate"
+g++ -std=c++20 -O2 -Wall -pthread $INC tests/ngeom/test_tessellate.cpp $TESS_LINK "$obj"/*.o -o "$obj/test_tessellate"
 "$obj/test_tessellate"
-g++ -std=c++20 -O2 -Wall $INC tests/ngeom/test_solidify_manifold.cpp $TESS_LINK "$obj"/*.o \
+g++ -std=c++20 -O2 -Wall -pthread $INC tests/ngeom/test_solidify_manifold.cpp $TESS_LINK "$obj"/*.o \
     -o "$obj/test_solidify_manifold"
 "$obj/test_solidify_manifold"
-g++ -std=c++20 -O2 -Wall $INC -I src/cadit/step tests/step/test_step_reader.cpp $TESS_LINK "$obj"/*.o \
+g++ -std=c++20 -O2 -Wall -pthread $INC -I src/cadit/step tests/step/test_step_reader.cpp $TESS_LINK "$obj"/*.o \
     -o "$obj/test_step_reader"
 "$obj/test_step_reader"
 


### PR DESCRIPTION
Native, OCC-free tessellation of `IfcFixedReferenceSweptAreaSolid` swept over an alignment
directrix (`IfcGradientCurve`: clothoid + vertical gradient) — the C++ half of the
neutral-geometry (NGEOM) alignment pipeline.

## What
- `ngeom_topology.h`: new `SweepN` (planar profile face + placement frame + per-station
  directrix `origin`/`dir_x`/`dir_y` fields); `sweep` slot on `SolidItemN` / `NgeomRoot`.
- `ngeom_decode.h`: decode the new `FIXED_REF_SWEPT_SOLID` record (tag 54) — profile FACE
  ref + PLACEMENT3 + per-station frame field.
- `ngeom_tessellate.cpp`: `tessellate_sweep` — side walls connect consecutive profile rings;
  first/last stations get libtess2 end caps (profile triangulated in local UV, holes honoured).
  Wired into `tessellate_solid_item` / `tessellate_doc`.

## Why this split
The analytic directrix (real Fresnel clothoid + vertical gradient + fixed-reference frame) is
evaluated **producer-side** (adapy) into the per-station frame field, so the kernel only rings +
caps it — no OCC, no Frenet roll here. A pure-C++ analytic eval in the taxonomy reader remains a
clean follow-up if the native C++ IFC reader ever needs alignment directly.

## Validated (adapy side, via the real native path)
`from_ifc -> NGEOM serialize -> tessellate_stream (libtess2)`: one closed shell, 7220 tris,
bbox min exact `[-1e-3, -213.95, 148.515]`, max x,y exact. Drives both GLB (7220 tris) and a
faceted STEP `MANIFOLD_SOLID_BREP` (watertight, V-E+F=2). Fixes audit #48 parity
(`fixed-reference-swept-area-solid.ifc -> step`: 15202 -> 1 solid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)