### PR TITLE
feat: Add imprint_planar_faces; fix the win-64 build and the cad API generator's encoding

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -122,7 +122,11 @@ echo = { cmd = "echo \"$CONDA_PREFIX\"", description = "Echo Hello World" }
 echo2 = { cmd = "echo \"$SP_DIR\"", description = "Echo Hello World" }
 
 [feature.test.target.win-64.tasks]
-install = { cmd = "cmake --preset pixi-test-win && cmake --build build && cmake --install build", description = "Build and install with CMake", inputs = [
+# The vs2022 conda activation exports CMAKE_GENERATOR="Visual Studio 17 2022" +
+# CMAKE_GENERATOR_PLATFORM=x64, but the preset builds with Ninja, which rejects any
+# platform spec ("Generator Ninja does not support platform specification") and then
+# fails to find the compiler at all. Unset them so the preset's generator wins.
+install = { cmd = "unset CMAKE_GENERATOR CMAKE_GENERATOR_PLATFORM CMAKE_GENERATOR_TOOLSET && cmake --preset pixi-test-win && cmake --build build && cmake --install build", description = "Build and install with CMake", inputs = [
     "CMakeLists.txt",
     "CMakePresets.json",
     "cmake/**/*.cmake",
@@ -134,6 +138,17 @@ install = { cmd = "cmake --preset pixi-test-win && cmake --build build && cmake 
 ], outputs = [
     "build/STP2GLB.exe",
     "build/_ada_cpp_ext_impl*.pyd",
+] }
+# Win-64 mirror of the linux build-dist below — see the note there.
+build-dist = { cmd = "unset CMAKE_GENERATOR CMAKE_GENERATOR_PLATFORM CMAKE_GENERATOR_TOOLSET && cmake --preset pixi-test-win && cmake --build build && rm -rf build/dist && mkdir -p build/dist && cp -r src/adacpp build/dist/adacpp && cp build/_ada_cpp_ext_impl*.pyd build/dist/adacpp/ && echo \"bleeding-edge adacpp -> $PIXI_PROJECT_ROOT/build/dist  (bridge via PYTHONPATH)\"", description = "Build native ext + assemble an importable adacpp at build/dist for PYTHONPATH bridging", inputs = [
+    "CMakeLists.txt",
+    "CMakePresets.json",
+    "cmake/**/*.cmake",
+    "src/**/*.cpp",
+    "src/**/*.h",
+    "src/**/*.hpp",
+    "src/**/*.hxx",
+    "src/adacpp/**/*.py",
 ] }
 stp2glb = { cmd = "STP2GLB.exe", description = "Run the C++ tests" }
 

--- a/src/adacpp/cad/__init__.py
+++ b/src/adacpp/cad/__init__.py
@@ -47,6 +47,9 @@ AdvancedFaceData = _cad.AdvancedFaceData
 Color = _cad.Color
 GroupReference = _cad.GroupReference
 IfcNgeomStream = _cad.IfcNgeomStream
+ImprintResult = _cad.ImprintResult
+ImprintedEdge = _cad.ImprintedEdge
+ImprintedFace = _cad.ImprintedFace
 Mesh = _cad.Mesh
 MeshType = _cad.MeshType
 PcurveData = _cad.PcurveData
@@ -92,6 +95,7 @@ faces = _cad.faces
 free_faces = _cad.free_faces
 from_topods_pointer = _cad.from_topods_pointer
 ifc_taxonomy_settings = _cad.ifc_taxonomy_settings
+imprint_planar_faces = _cad.imprint_planar_faces
 is_valid = _cad.is_valid
 loft_profiles = _cad.loft_profiles
 make_box = _cad.make_box
@@ -159,6 +163,9 @@ __all__ = [
     "Color",
     "GroupReference",
     "IfcNgeomStream",
+    "ImprintResult",
+    "ImprintedEdge",
+    "ImprintedFace",
     "Mesh",
     "MeshType",
     "PcurveData",
@@ -205,6 +212,7 @@ __all__ = [
     "from_topods_pointer",
     "glb_diff",
     "ifc_taxonomy_settings",
+    "imprint_planar_faces",
     "is_valid",
     "loft_profiles",
     "make_box",

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -224,6 +224,43 @@ struct StepShapeData {
 };
 
 // ----------------------------------------------------------------------------
+// Result structs for imprint_planar_faces (the General-Fuse planar imprint).
+// Plain data, bound read-only; adapy turns them into ACIS SAT topology for the
+// Genie exporter. Mirrors ada.cad.PlanarImprint / ImprintedEdge / ImprintedFace.
+// ----------------------------------------------------------------------------
+
+// A straight edge, as indices into ImprintResult::vertices.
+struct ImprintedEdge {
+    int start = 0;
+    int end = 0;
+};
+
+struct ImprintedFace {
+    std::array<double, 3> origin{};
+    std::array<double, 3> normal{};
+    std::array<double, 3> ref_direction{};
+    // loops[0] is the outer boundary, the rest are holes. Each entry is an
+    // (edge index, forward) pair; forward=false means the loop runs that edge
+    // from its `end` vertex to its `start`. Every loop winds counter-clockwise
+    // about `normal`.
+    std::vector<std::vector<std::pair<int, bool>>> loops;
+};
+
+struct ImprintResult {
+    std::vector<std::array<double, 3>> vertices;
+    std::vector<ImprintedEdge> edges;
+    std::vector<ImprintedFace> faces;
+    // sources[i] = the faces the i-th input outline became.
+    std::vector<std::vector<int>> sources;
+    // curve_sources[i] = the edges the i-th imprint curve became.
+    std::vector<std::vector<int>> curve_sources;
+    // Edges that bound no face (an imprint curve with no face under it). Still
+    // reported, and still reachable via curve_sources: a consumer needs geometry
+    // for them, carried as wire bodies rather than face boundaries.
+    std::vector<int> free_edges;
+};
+
+// ----------------------------------------------------------------------------
 // Primitive factories — single OCCT-backed code path on native + wasm
 // ----------------------------------------------------------------------------
 
@@ -1405,6 +1442,199 @@ ShapeHandle non_manifold_merge_impl(const std::vector<ShapeHandle> &shapes, doub
     if (builder.HasErrors())
         throw std::runtime_error("non_manifold_merge: BOPAlgo_Builder reported errors");
     return ShapeHandle(builder.Shape());
+}
+
+// General-Fuse a set of planar outlines against each other and against
+// `imprint_curves`, returning the merged topology as plain data.
+//
+// Unlike non_manifold_merge this keeps the Modified() history, which is what
+// maps an input outline to the faces it became — the caller needs that to name
+// the faces a plate resolves to. Imprint curves (beam axes) split a face along
+// their line where they lie on it, and drop a vertex where they merely cross
+// it; they survive the fuse as free edges and are deliberately not reported.
+//
+// The whole model is imprinted and extracted in one call: crossing the
+// Python/C++ boundary per face or per edge would dominate the cost.
+ImprintResult imprint_planar_faces_impl(const std::vector<std::vector<std::array<double, 3>>> &outlines,
+                                        const std::vector<std::vector<std::array<double, 3>>> &imprint_curves,
+                                        double tolerance) {
+    ImprintResult out;
+    if (outlines.empty())
+        return out;
+
+    auto mkface = [](const std::vector<std::array<double, 3>> &pts) {
+        if (pts.size() < 3)
+            throw std::runtime_error("imprint_planar_faces: an outline needs at least 3 points");
+        BRepBuilderAPI_MakePolygon mp;
+        for (const auto &p : pts)
+            mp.Add(gp_Pnt(p[0], p[1], p[2]));
+        mp.Close();
+        return TopoDS::Face(BRepBuilderAPI_MakeFace(mp.Wire(), Standard_True).Face());
+    };
+
+    const double tol = tolerance > 0.0 ? tolerance : 1e-12;
+    // One TopoDS_Edge per segment rather than a wire: BOPAlgo's history is
+    // per-argument, and edges give a direct Modified(edge) -> split edges map,
+    // which is what resolves a beam axis to the edges it became.
+    auto mkedges = [&tol](const std::vector<std::array<double, 3>> &pts) {
+        std::vector<TopoDS_Edge> out;
+        for (std::size_t i = 0; i + 1 < pts.size(); ++i) {
+            gp_Pnt a(pts[i][0], pts[i][1], pts[i][2]);
+            gp_Pnt b(pts[i + 1][0], pts[i + 1][1], pts[i + 1][2]);
+            if (a.Distance(b) <= tol)
+                continue; // a zero-length segment would fail the edge build
+            out.push_back(BRepBuilderAPI_MakeEdge(a, b).Edge());
+        }
+        return out;
+    };
+
+    std::vector<TopoDS_Face> inputs;
+    inputs.reserve(outlines.size());
+    for (const auto &o : outlines)
+        inputs.push_back(mkface(o));
+
+    // per curve, the argument edges it contributed
+    std::vector<std::vector<TopoDS_Edge>> curve_edges;
+    std::vector<TopoDS_Edge> cutters;
+    for (const auto &c : imprint_curves) {
+        curve_edges.push_back(mkedges(c));
+        for (const auto &e : curve_edges.back())
+            cutters.push_back(e);
+    }
+
+    TopoDS_Shape res;
+    BOPAlgo_Builder builder;
+    const bool fused = inputs.size() + cutters.size() >= 2;
+    if (!fused) {
+        // General Fuse needs at least two arguments (it raises TooFewArguments
+        // otherwise). A lone outline has nothing to imprint against.
+        res = inputs[0];
+    } else {
+        TopTools_ListOfShape args;
+        for (const auto &f : inputs)
+            args.Append(f);
+        for (const auto &w : cutters)
+            args.Append(w);
+        builder.SetArguments(args);
+        if (tolerance > 0.0)
+            builder.SetFuzzyValue(tolerance);
+        builder.SetRunParallel(Standard_True);
+        builder.Perform();
+        if (builder.HasErrors())
+            throw std::runtime_error("imprint_planar_faces: BOPAlgo_Builder reported errors");
+        res = builder.Shape();
+    }
+
+    // Index the unique sub-shapes. The map's hasher keys on TShape+Location and
+    // ignores orientation, so a FORWARD and a REVERSED use of the same edge
+    // collapse to one index — exactly the sharing we want.
+    //
+    // Index the whole result, faces and free edges alike: an imprint curve with
+    // no face under it survives as a free edge, and the caller still needs
+    // geometry for it (carried as a wire body). Which is which -> free_edges.
+    TopTools_IndexedMapOfShape fmap, vmap, emap;
+    TopExp::MapShapes(res, TopAbs_FACE, fmap);
+    TopExp::MapShapes(res, TopAbs_VERTEX, vmap);
+    TopExp::MapShapes(res, TopAbs_EDGE, emap);
+
+    TopTools_IndexedDataMapOfShapeListOfShape edge_faces;
+    TopExp::MapShapesAndAncestors(res, TopAbs_EDGE, TopAbs_FACE, edge_faces);
+    for (int i = 1; i <= emap.Extent(); ++i) {
+        const TopoDS_Shape &e = emap.FindKey(i);
+        if (!edge_faces.Contains(e) || edge_faces.FindFromKey(e).IsEmpty())
+            out.free_edges.push_back(i - 1);
+    }
+
+    out.vertices.reserve(vmap.Extent());
+    for (int i = 1; i <= vmap.Extent(); ++i) {
+        gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(vmap.FindKey(i)));
+        out.vertices.push_back({p.X(), p.Y(), p.Z()});
+    }
+
+    out.edges.reserve(emap.Extent());
+    for (int i = 1; i <= emap.Extent(); ++i) {
+        TopoDS_Edge e = TopoDS::Edge(emap.FindKey(i).Oriented(TopAbs_FORWARD));
+        ImprintedEdge rec;
+        rec.start = vmap.FindIndex(TopExp::FirstVertex(e, Standard_True)) - 1;
+        rec.end = vmap.FindIndex(TopExp::LastVertex(e, Standard_True)) - 1;
+        out.edges.push_back(rec);
+    }
+
+    out.faces.reserve(fmap.Extent());
+    for (int i = 1; i <= fmap.Extent(); ++i) {
+        TopoDS_Face f = TopoDS::Face(fmap.FindKey(i));
+        BRepAdaptor_Surface surf(f, Standard_True);
+        if (surf.GetType() != GeomAbs_Plane)
+            throw std::runtime_error("imprint_planar_faces: result contains a non-planar face");
+        gp_Pln pln = surf.Plane();
+        gp_Pnt loc = pln.Location();
+        gp_Dir ax = pln.Axis().Direction();
+        gp_Dir xd = pln.XAxis().Direction();
+
+        ImprintedFace rec;
+        rec.origin = {loc.X(), loc.Y(), loc.Z()};
+        rec.normal = {ax.X(), ax.Y(), ax.Z()};
+        rec.ref_direction = {xd.X(), xd.Y(), xd.Z()};
+        // A REVERSED face's true outward normal is the opposite of its
+        // surface's; flipping here keeps every loop below wound
+        // counter-clockwise about the normal we report.
+        if (f.Orientation() == TopAbs_REVERSED)
+            rec.normal = {-rec.normal[0], -rec.normal[1], -rec.normal[2]};
+
+        TopoDS_Wire outer = BRepTools::OuterWire(f);
+        std::vector<TopoDS_Wire> wires;
+        for (TopExp_Explorer wexp(f, TopAbs_WIRE); wexp.More(); wexp.Next())
+            wires.push_back(TopoDS::Wire(wexp.Current()));
+        std::stable_sort(wires.begin(), wires.end(), [&outer](const TopoDS_Wire &a, const TopoDS_Wire &b) {
+            return a.IsSame(outer) && !b.IsSame(outer); // outer loop first
+        });
+
+        for (const auto &w : wires) {
+            std::vector<std::pair<int, bool>> loop;
+            for (BRepTools_WireExplorer we(w, f); we.More(); we.Next()) {
+                const TopoDS_Edge &edge = we.Current();
+                loop.emplace_back(emap.FindIndex(edge) - 1, edge.Orientation() == TopAbs_FORWARD);
+            }
+            rec.loops.push_back(std::move(loop));
+        }
+        out.faces.push_back(std::move(rec));
+    }
+
+    // The result sub-shapes an argument became, as indices into `index_map`.
+    // Only ones present in the map count: an imprint curve with no face under it
+    // survives as a free edge, which bounds nothing and is deliberately absent.
+    auto history = [&](const TopoDS_Shape &shape, const TopTools_IndexedMapOfShape &index_map) {
+        std::vector<int> got;
+        if (!fused) {
+            if (index_map.Contains(shape))
+                got.push_back(index_map.FindIndex(shape) - 1);
+            return got;
+        }
+        const TopTools_ListOfShape &mods = builder.Modified(shape);
+        if (!mods.IsEmpty()) {
+            for (TopTools_ListOfShape::Iterator it(mods); it.More(); it.Next())
+                if (index_map.Contains(it.Value()))
+                    got.push_back(index_map.FindIndex(it.Value()) - 1);
+        } else if (!builder.IsDeleted(shape) && index_map.Contains(shape)) {
+            got.push_back(index_map.FindIndex(shape) - 1); // untouched: passes through as itself
+        }
+        return got;
+    };
+
+    out.sources.reserve(inputs.size());
+    for (const auto &f : inputs)
+        out.sources.push_back(history(f, fmap));
+
+    out.curve_sources.reserve(curve_edges.size());
+    for (const auto &edges_ : curve_edges) {
+        std::vector<int> got;
+        for (const auto &e : edges_)
+            for (int idx : history(e, emap))
+                if (std::find(got.begin(), got.end(), idx) == got.end())
+                    got.push_back(idx);
+        out.curve_sources.push_back(std::move(got));
+    }
+    return out;
 }
 
 // Faithful port of topologic's Topology::Merge over solids: general-fuse the
@@ -3558,6 +3788,25 @@ void cad_module(nb::module_ &m) {
         .def_ro("transforms", &StepRootMeta::transforms)
         .def_ro("instance_paths", &StepRootMeta::instance_paths);
 
+    // Inner classes first — ImprintResult exposes vectors of these.
+    nb::class_<ImprintedEdge>(m, "ImprintedEdge")
+        .def_ro("start", &ImprintedEdge::start)
+        .def_ro("end", &ImprintedEdge::end);
+
+    nb::class_<ImprintedFace>(m, "ImprintedFace")
+        .def_ro("origin", &ImprintedFace::origin)
+        .def_ro("normal", &ImprintedFace::normal)
+        .def_ro("ref_direction", &ImprintedFace::ref_direction)
+        .def_ro("loops", &ImprintedFace::loops);
+
+    nb::class_<ImprintResult>(m, "ImprintResult")
+        .def_ro("vertices", &ImprintResult::vertices)
+        .def_ro("edges", &ImprintResult::edges)
+        .def_ro("faces", &ImprintResult::faces)
+        .def_ro("sources", &ImprintResult::sources)
+        .def_ro("curve_sources", &ImprintResult::curve_sources)
+        .def_ro("free_edges", &ImprintResult::free_edges);
+
     nb::class_<PcurveData>(m, "PcurveData")
         .def_ro("has_pcurve", &PcurveData::has_pcurve)
         .def_ro("degree", &PcurveData::degree)
@@ -4179,6 +4428,13 @@ void cad_module(nb::module_ &m) {
     m.def("non_manifold_merge", &non_manifold_merge_impl, "shapes"_a, "tolerance"_a = 1e-6, "glue"_a = true,
           "Non-manifold fuse (BOPAlgo_Builder) keeping coincident faces shared "
           "between adjacent solids rather than dissolving the partition.");
+
+    m.def("imprint_planar_faces", &imprint_planar_faces_impl, "outlines"_a,
+          "imprint_curves"_a = std::vector<std::vector<std::array<double, 3>>>(), "tolerance"_a = 1e-6,
+          "General-Fuse planar outlines against each other and against imprint_curves "
+          "(e.g. beam axes), returning the merged topology as plain data: welded "
+          "vertices, shared edges, per-face loops, and sources mapping each input "
+          "outline to the faces it became. Ports adapy OccBackend.imprint_planar_faces.");
 
     m.def("merge_cells", &merge_cells_impl, "solids"_a, "tolerance"_a = 0.0,
           "Faithful port of topologic Topology::Merge over solids "

--- a/tests/py/test_basic.py
+++ b/tests/py/test_basic.py
@@ -836,3 +836,92 @@ def test_cad_non_manifold_merge_keeps_shared_face():
     sols = list(adacpp.cad.solids(comp))
     assert len(sols) == 2
     assert len(adacpp.cad.free_faces(sols)) == 10
+
+
+DECK = [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)]
+BULKHEAD = [(0, 5, 0), (10, 5, 0), (10, 5, 5), (0, 5, 5)]
+
+
+def test_cad_imprint_planar_faces_single_outline_passes_through():
+    """One outline has nothing to imprint against (and General Fuse rejects a
+    lone argument), so it must come back as itself."""
+    res = adacpp.cad.imprint_planar_faces([DECK])
+    assert len(res.faces) == 1
+    assert [list(s) for s in res.sources] == [[0]]
+    assert len(res.vertices) == 4
+
+
+def test_cad_imprint_planar_faces_splits_at_a_t_junction():
+    """A deck crossed by a bulkhead splits into two faces sharing one edge, and
+    the history maps the deck to both halves."""
+    res = adacpp.cad.imprint_planar_faces([DECK, BULKHEAD])
+
+    assert len(res.faces) == 3
+    assert len(res.sources[0]) == 2  # deck split
+    assert len(res.sources[1]) == 1  # bulkhead intact
+    assert not set(res.sources[0]) & set(res.sources[1])
+    assert len(res.vertices) == 8  # welded, not 4 + 4
+
+    # the imprint line is ONE edge, used by all three faces
+    uses = {}
+    for f in res.faces:
+        for loop in f.loops:
+            for edge_idx, _ in loop:
+                uses[edge_idx] = uses.get(edge_idx, 0) + 1
+    assert max(uses.values()) == 3
+
+
+def test_cad_imprint_planar_faces_imprints_a_curve():
+    """A stiffener axis lying on a plate splits it along its line — where most
+    of a stiffened panel's face count comes from."""
+    res = adacpp.cad.imprint_planar_faces([DECK], [[(5, 0, 0), (5, 10, 0)]])
+    assert len(res.faces) == 2
+    assert len(res.sources[0]) == 2
+
+
+def test_cad_imprint_planar_faces_reports_the_edges_a_curve_became():
+    """curve_sources maps a beam axis to the edges it became, so the caller can
+    name them — without it a beam's SAT reference is empty and the consumer
+    rebuilds its geometry."""
+    # one axis across the deck, split in two by a second crossing it
+    res = adacpp.cad.imprint_planar_faces([DECK], [[(5, 0, 0), (5, 10, 0)], [(0, 5, 0), (10, 5, 0)]])
+    assert len(res.curve_sources) == 2
+    for src in res.curve_sources:
+        assert len(src) == 2  # each axis split where the other crosses it
+        for edge_idx in src:
+            assert 0 <= edge_idx < len(res.edges)
+    assert not set(res.curve_sources[0]) & set(res.curve_sources[1])
+
+
+def test_cad_imprint_planar_faces_curve_off_the_face_is_a_free_edge():
+    """An axis with no face under it still needs geometry — it is reported as a
+    free edge (the caller carries those as wire bodies), not dropped."""
+    res = adacpp.cad.imprint_planar_faces([DECK], [[(0, 0, 9), (10, 0, 9)]])
+    assert len(res.curve_sources[0]) == 1
+    assert list(res.free_edges) == list(res.curve_sources[0])
+    # ...and it is genuinely not part of any face loop
+    on_a_face = {i for f in res.faces for loop in f.loops for i, _ in loop}
+    assert not on_a_face & set(res.free_edges)
+
+
+def test_cad_imprint_planar_faces_face_edges_are_not_free():
+    res = adacpp.cad.imprint_planar_faces([DECK, BULKHEAD])
+    assert list(res.free_edges) == []
+
+
+def test_cad_imprint_planar_faces_loops_wind_about_the_normal():
+    """ACIS-style consumers derive a face's material side from its loop winding
+    versus its normal, so every loop must wind counter-clockwise about it."""
+    res = adacpp.cad.imprint_planar_faces([DECK, BULKHEAD])
+    for f in res.faces:
+        pts = []
+        for edge_idx, forward in f.loops[0]:
+            e = res.edges[edge_idx]
+            pts.append(res.vertices[e.start if forward else e.end])
+        n = [0.0, 0.0, 0.0]
+        for i, a in enumerate(pts):
+            b = pts[(i + 1) % len(pts)]
+            n[0] += (a[1] - b[1]) * (a[2] + b[2])
+            n[1] += (a[2] - b[2]) * (a[0] + b[0])
+            n[2] += (a[0] - b[0]) * (a[1] + b[1])
+        assert sum(x * y for x, y in zip(n, f.normal)) > 0

--- a/tests/py/test_cad_api_generated.py
+++ b/tests/py/test_cad_api_generated.py
@@ -67,7 +67,8 @@ def _load_generator():
 
 def _cpp_optional_names() -> set[str]:
     """Bindings the C++ compiles only into the native build. Authoritative; needs the source tree."""
-    return _load_generator().native_only_bindings((_ROOT / "src" / "cad" / "cad_py_wrap.cpp").read_text())
+    cpp = (_ROOT / "src" / "cad" / "cad_py_wrap.cpp").read_text(encoding="utf-8")
+    return _load_generator().native_only_bindings(cpp)
 
 
 def _optional_names() -> set[str]:
@@ -77,7 +78,7 @@ def _optional_names() -> set[str]:
     behaviour — valid anywhere. test_declared_optionals_match_the_cpp pins this against the C++
     guards so the self-declaration cannot drift into a comfortable lie.
     """
-    return set(re.findall(r"^(\w+) = _optional\(", _INSTALLED.read_text(), re.M))
+    return set(re.findall(r"^(\w+) = _optional\(", _INSTALLED.read_text(encoding="utf-8"), re.M))
 
 
 def test_every_binding_is_re_exported():
@@ -110,7 +111,10 @@ def test_generated_file_is_not_stale():
     """The checked-in file must equal what the generator emits for this extension."""
     gen = _load_generator()
     out = _ROOT / "src" / "adacpp" / "cad" / "__init__.py"
-    assert out.read_text() == gen.generate(), "adacpp/cad/__init__.py is stale — run `pixi run gen-cad-api`"
+    # utf-8 explicitly: the file has non-ASCII, and read_text() would otherwise
+    # decode it as cp1252 on Windows and never match, whatever it contains
+    current = out.read_text(encoding="utf-8")
+    assert current == gen.generate(), "adacpp/cad/__init__.py is stale — run `pixi run gen-cad-api`"
 
 
 @_needs_src
@@ -143,7 +147,7 @@ def test_conditional_bindings_are_not_bound_flat():
     Regression: `glb_diff = _cad.glb_diff` raised AttributeError at import under pyodide and killed the
     whole module. The generator emits _optional() for these; this pins that it keeps doing so.
     """
-    src = _INSTALLED.read_text()
+    src = _INSTALLED.read_text(encoding="utf-8")
     for name in _optional_names():
         assert (
             f"\n{name} = _cad.{name}\n" not in src
@@ -203,7 +207,7 @@ def _exec_generated_as_wasm():
     way cannot run at all. Exec'ing the real file's source against a stand-in _cad tests the same
     code with no global mutation.
     """
-    src = _INSTALLED.read_text()
+    src = _INSTALLED.read_text(encoding="utf-8")
     imp = "from .._ada_cpp_ext_impl import cad as _cad"
     assert imp in src, "generated import line changed — this fake-injection is no longer faithful"
     fake = types.SimpleNamespace(**{n: getattr(_cad, n) for n in _PUBLIC - _optional_names()})

--- a/tools/gen_cad_api.py
+++ b/tools/gen_cad_api.py
@@ -175,7 +175,7 @@ def generate() -> str:
     except ImportError as exc:  # pragma: no cover
         raise SystemExit(f"build the extension first (pixi run build-dist): {exc}") from exc
     names = sorted(n for n in dir(_cad) if not n.startswith("_"))
-    optional = native_only_bindings(_WRAP.read_text())
+    optional = native_only_bindings(_WRAP.read_text(encoding="utf-8"))
     # Generation must read a NATIVE build: it is the only one with the full surface. Generating from a
     # wasm build would silently emit a module missing every native-only name, and since the wasm build
     # cannot see them, nothing downstream would notice. Fail loudly instead.
@@ -194,14 +194,18 @@ def main() -> int:
     ap.add_argument("--check", action="store_true", help="exit 1 if the checked-in file is stale")
     args = ap.parse_args()
     new = generate()
+    # Always utf-8: the emitted module and the C++ it is derived from both contain
+    # non-ASCII, and read_text/write_text otherwise follow the platform default —
+    # cp1252 on Windows, which silently rewrites every em-dash to U+FFFD. That
+    # corrupts the file on write and makes --check compare against a mangled read.
     if args.check:
-        cur = _OUT.read_text() if _OUT.exists() else ""
+        cur = _OUT.read_text(encoding="utf-8") if _OUT.exists() else ""
         if cur != new:
             print(f"{_OUT} is STALE — run `pixi run gen-cad-api`", file=sys.stderr)
             return 1
         print(f"{_OUT} is up to date")
         return 0
-    _OUT.write_text(new)
+    _OUT.write_text(new, encoding="utf-8")
     print(f"wrote {_OUT} ({len(new.splitlines())} lines)")
     return 0
 


### PR DESCRIPTION
Three independent changes, one per commit. Rebased on `0.14.0`.

> The wasm-import fix that was originally the first commit here is dropped — #39 carries it. Its re-export generator is now the source of truth for `adacpp/cad/__init__.py`, and this branch regenerates rather than hand-editing it.

### 1. `build(win)`: unset the VS generator vars so the Ninja preset configures

conda's vs2022 activation exports `CMAKE_GENERATOR="Visual Studio 17 2022"` and `CMAKE_GENERATOR_PLATFORM=x64`, but `pixi-test-win` builds with Ninja, which rejects any platform spec. The win-64 `install` task couldn't configure at all, and the error pointed at the wrong thing:

```
Generator Ninja does not support platform specification, but platform x64 was specified.
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
```

The toolchain was fine — cmake bailed before it ever probed for a compiler. Also adds a win-64 `build-dist` mirroring the linux one; the PYTHONPATH-bridging dist had no win equivalent.

### 2. `fix(tools)`: read and write the cad API layer as utf-8

`gen_cad_api.py` and its test used `read_text()`/`write_text()` with no encoding, so both follow the platform default — utf-8 on linux, cp1252 on Windows — and the generated module's docstring contains em-dashes. So on Windows:

- generating rewrote every em-dash to U+FFFD, corrupting a file whose only legitimate diff was the new bindings;
- `test_generated_file_is_not_stale` compared a cp1252 read of a utf-8 file against the generator's in-memory string, and so failed whatever the file contained — advising "run `pixi run gen-cad-api`" when that is exactly what had just been run.

Both now name utf-8. The emitted content is unchanged, and `--check` against the file already in main passes before and after on linux. Found while regenerating for the commit below; it is a prerequisite for doing that on Windows at all.

### 3. `feat(cad)`: add `imprint_planar_faces`

General-Fuse planar outlines against each other and against imprint curves, returning the merged topology as plain data. Ports adapy's `OccBackend.imprint_planar_faces` so the Genie SAT export works on this backend — and therefore under pyodide, where pythonocc doesn't exist.

`non_manifold_merge` already runs `BOPAlgo_Builder`, but discards the `Modified()` history and returns an opaque `ShapeHandle`. Both are exactly what's needed here: the history maps an input to what it became, and building ACIS topology means walking every loop, coedge and vertex — which must not happen one Python/C++ crossing at a time. So the whole model is imprinted and extracted in a single call returning:

| field | meaning |
|---|---|
| `vertices` / `edges` / `faces` | welded topology; an edge shared by N faces appears once |
| `sources[i]` | the faces the i-th outline became |
| `curve_sources[i]` | the edges the i-th imprint curve became |
| `free_edges` | edges bounding no face (a curve with no face under it) |

Imprint curves are added as individual `TopoDS_Edge` arguments rather than wires, because BOPAlgo's history is per-argument and edges give a direct `Modified(edge) -> split edges` map.

The four new names are picked up by #39's generator — `src/adacpp/cad/__init__.py` is regenerated, not hand-edited, so its diff is exactly the new bindings.

### Testing

82 tests pass (`pixi run -e test test`), including #39's ten generated-API tests. The new ones cover the T-junction split, welded vertices, an edge shared by three faces, loop winding vs. the face normal, the curve→edge history, and free edges.

Verified against the OCC backend through adapy: identical entity counts and face boundaries on the same model, wire bodies included.
