### PR TITLE
feat: native OCC-free STEP/IFC to GLB with tessellation tracks and colour/curved-surface fidelity

### DIFF
--- a/.github/workflows/build-stp2glb.yaml
+++ b/.github/workflows/build-stp2glb.yaml
@@ -1,8 +1,9 @@
 name: build-stp2glb
 
-# Build the standalone OCC-free STP2GLB CLI (no OCCT/CGAL/gmsh/IFC/Python) and publish the Linux
-# binary as a downloadable artifact. Runs on push/dispatch; on a tag push it also attaches the
-# binary to the GitHub release.
+# Build the standalone OCC-free STP2GLB CLI (no OCCT/CGAL/gmsh/IFC/Python) for Linux and Windows and
+# publish each binary as a downloadable artifact. The C++ runtime is static-linked, so the binaries
+# run with no conda env / VC++ redist. Runs on push/dispatch; on a tag push each job also attaches
+# its binary to the GitHub release.
 on:
   workflow_dispatch:
 
@@ -41,14 +42,16 @@ jobs:
         run: |
           pixi run -e stp2glb build-stp2glb
 
-      - name: sanity-check the binary (OCC-free)
+      - name: sanity-check the binary (OCC-free + standalone)
         run: |
           bin=build-stp2glb/STP2GLB
           test -x "$bin"
           ./"$bin" --help
-          # Fail loudly if any OCCT toolkit (libTK*) leaked into the link.
-          if ldd "$bin" | grep -qiE 'libTK'; then
-            echo "ERROR: STP2GLB linked an OCCT toolkit (libTK*) — not OCC-free" >&2
+          # The released CLI must be standalone: no OCCT toolkit (libTK*) and no dynamic C++ runtime
+          # (libstdc++/libgcc are static-linked), so it runs with no conda env. glibc stays dynamic
+          # (OS-provided) by design.
+          if ldd "$bin" | grep -qiE 'libTK|libstdc\+\+|libgcc_s'; then
+            echo "ERROR: STP2GLB linked OCCT or a dynamic C++ runtime — not standalone" >&2
             ldd "$bin"
             exit 1
           fi
@@ -67,3 +70,55 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: build-stp2glb/STP2GLB
+
+  build_stp2glb_win:
+    name: stp2glb-standalone-win
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          pixi-version: latest
+          environments: stp2glb
+          cache: true
+
+      # Same lean OCC-free standalone config as Linux; the win-64 pixi task fixes the header path
+      # (Library/include) and unsets the Visual Studio generator vars so the Ninja preset wins.
+      - name: build standalone STP2GLB.exe
+        run: |
+          pixi run -e stp2glb build-stp2glb
+
+      - name: sanity-check the binary (runs + standalone)
+        run: |
+          bin=build-stp2glb/STP2GLB.exe
+          test -f "$bin"
+          ./"$bin" --help
+          # A standalone CLI must import only system DLLs (KERNEL32 + the api-ms-win-crt UCRT, which
+          # ships with Windows). The MSVC runtime is static-linked, so fail if MSVCP140/VCRUNTIME140
+          # (VC++ redist) or any OCCT toolkit leaked into the imports.
+          pixi run -e stp2glb bash -c "dumpbin //dependents '$bin'" > deps.txt
+          cat deps.txt
+          if grep -qiE 'MSVCP140|VCRUNTIME140|libTK' deps.txt; then
+            echo "ERROR: STP2GLB.exe is not standalone (VC++ redist or OCCT leaked into imports)" >&2
+            exit 1
+          fi
+
+      - name: upload STP2GLB.exe artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: STP2GLB-win-64
+          path: build-stp2glb/STP2GLB.exe
+          if-no-files-found: error
+
+      # On a tag push, also attach the Windows binary to the corresponding GitHub release.
+      - name: attach binary to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v3
+        with:
+          files: build-stp2glb/STP2GLB.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,19 @@ OPTION(BUILD_DEBUG_TESTS "Build the testing tree used primarily for debugging." 
 # python module are both skipped below regardless of how the caller set BUILD_PYTHON.
 if (BUILD_STP2GLB_STANDALONE)
     set(BUILD_PYTHON OFF CACHE BOOL "Disabled by BUILD_STP2GLB_STANDALONE" FORCE)
+    # Ship a portable CLI: statically link the C++ runtime so the released binary runs with no conda
+    # env, no Visual C++ redistributable, and no dependency on the host libstdc++ version. MSVC ->
+    # static /MT runtime; GCC/Clang -> static libstdc++/libgcc (glibc stays dynamic, as intended).
+    # Set before any target / FetchContent so every object in the standalone build agrees.
+    if (POLICY CMP0091)
+        cmake_policy(SET CMP0091 NEW)  # honour CMAKE_MSVC_RUNTIME_LIBRARY
+    endif ()
+    if (MSVC)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+            CACHE STRING "Static MSVC runtime for the standalone CLI" FORCE)
+    else ()
+        add_link_options(-static-libstdc++ -static-libgcc)
+    endif ()
 endif ()
 
 if (DEFINED TINY_INCLUDE_DIR)

--- a/pixi.toml
+++ b/pixi.toml
@@ -207,6 +207,14 @@ gxx = "*"
 # path; CMAKE_PREFIX_PATH lets find_package(Threads) + manifold resolve against the lean env.
 build-stp2glb = { cmd = "cmake -S . -B build-stp2glb -G Ninja -DBUILD_STP2GLB_STANDALONE=ON -DBUILD_PYTHON=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$CONDA_PREFIX -DTINY_INCLUDE_DIR=$CONDA_PREFIX/include && cmake --build build-stp2glb --target STP2GLB && echo \"STP2GLB -> $PIXI_PROJECT_ROOT/build-stp2glb/STP2GLB\"", description = "Build ONLY the OCC-free standalone STP2GLB CLI (no OCCT/CGAL/gmsh/IFC/Python)" }
 
+[feature.stp2glb.target.win-64.tasks]
+# Win-64 mirror of the standalone build. Two platform diffs: CLI11 headers live under Library/include
+# on Windows (not include/), and the Ninja preset needs the Visual Studio generator env vars unset
+# (same as build-dist). Same OCC-free BUILD_STP2GLB_STANDALONE config — the CMake standalone block
+# static-links the MSVC runtime, so the resulting STP2GLB.exe imports only KERNEL32 (no VC++ redist,
+# no conda env).
+build-stp2glb = { cmd = "unset CMAKE_GENERATOR CMAKE_GENERATOR_PLATFORM CMAKE_GENERATOR_TOOLSET && cmake -S . -B build-stp2glb -G Ninja -DBUILD_STP2GLB_STANDALONE=ON -DBUILD_PYTHON=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$CONDA_PREFIX -DTINY_INCLUDE_DIR=$CONDA_PREFIX/Library/include && cmake --build build-stp2glb --target STP2GLB && echo \"STP2GLB -> $PIXI_PROJECT_ROOT/build-stp2glb/STP2GLB.exe\"", description = "Build ONLY the OCC-free standalone STP2GLB.exe CLI on Windows" }
+
 [feature.test.target.linux-64.activation.env]
 STP2GLB_EXE_DIR = "$CONDA_PREFIX/bin"
 # python3.13 to match feature.common's python==3.13 pin (bumped for the pyodide

--- a/src/adacpp/cad/__init__.py
+++ b/src/adacpp/cad/__init__.py
@@ -124,6 +124,7 @@ sew_faces = _cad.sew_faces
 shape_type = _cad.shape_type
 shells = _cad.shells
 solids = _cad.solids
+step_bytes_to_glb_bytes = _cad.step_bytes_to_glb_bytes
 step_emit_ifc_brep = _cad.step_emit_ifc_brep
 step_parity = _cad.step_parity
 stream_ifc_to_glb = _cad.stream_ifc_to_glb
@@ -241,6 +242,7 @@ __all__ = [
     "shape_type",
     "shells",
     "solids",
+    "step_bytes_to_glb_bytes",
     "step_emit_ifc_brep",
     "step_parity",
     "stream_ifc_to_glb",

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -799,9 +799,11 @@ int stream_step_to_glb_impl(const std::string &in_path, const std::string &out_p
 // Parallel: LPT-ordered products across `num_threads` workers (0 = cgroup-aware auto). Returns the
 // number of products written, or -1 on error.
 int stream_ifc_to_glb_impl(const std::string &in_path, const std::string &out_path, double deflection,
-                           double angular_deg, bool meshopt, double model_scale, int num_threads) {
+                           double angular_deg, bool meshopt, double model_scale, int num_threads,
+                           const std::string &pipeline, bool face_regions, bool pin_boundary) {
     return (int) adacpp::stream_ifc_to_glb(in_path, out_path, deflection, angular_deg, meshopt,
-                                           /*spill_dir=*/"", model_scale, num_threads);
+                                           /*spill_dir=*/"", model_scale, num_threads, pipeline, face_regions,
+                                           pin_boundary);
 }
 
 // Threaded OCC-free STEP -> STL / OBJ (same reader + parallel tessellation as the GLB core, but bakes
@@ -4073,11 +4075,17 @@ void cad_module(nb::module_ &m) {
 
     m.def("stream_ifc_to_glb", &stream_ifc_to_glb_impl, "in_path"_a, "out_path"_a, "deflection"_a = 0.0,
           "angular_deg"_a = 20.0, "meshopt"_a = true, "model_scale"_a = 0.0, "num_threads"_a = 0,
+          "pipeline"_a = "libtess2", "face_regions"_a = false, "pin_boundary"_a = true,
           "Native IFC -> GLB file (no ifcopenshell, no OCC): IfcResolver resolves each product's "
-          "geometry + presentation colour + spatial-structure path, libtess2 tessellates, baked to "
+          "geometry + presentation colour + spatial-structure path, tessellates, baked to "
           "metres into a merge-by-colour GLB matching the viewer. LPT-ordered across num_threads "
           "workers (0=cgroup-aware auto); curve-only bodies (alignment axes) skipped. Returns products "
-          "written (-1 on error).");
+          "written (-1 on error, and likewise on an unknown pipeline name). pipeline selects the "
+          "tessellation track by name (see tess_tracks(); '' / 'libtess2' = default, 'cdt' = "
+          "watertight); face_regions bakes per-face clickable regions into scenes[0].extras; "
+          "pin_boundary is a libtess2-track option. Same three knobs as stream_step_to_glb and the "
+          "same meanings — both feed the same neutral tessellator and the same GLB writer, so none "
+          "of them was ever STEP-specific.");
 
     m.def("stream_step_to_mesh", &stream_step_to_mesh_impl, "in_path"_a, "out_path"_a, "fmt"_a, "deflection"_a = 2.0,
           "angular_deg"_a = 20.0, "num_threads"_a = 0, "model_scale"_a = 0.0,

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -881,8 +881,8 @@ nb::dict glb_diff_impl(const std::string &scene_path, const std::string &ref_pat
 // oracle). Creates a temp spill dir, runs step_to_glb_single, returns the triangle count.
 long stream_step_to_glb_st_impl(const std::string &in_path, const std::string &out_path, double deflection,
                                 double angular_deg, bool meshopt) {
-    char tmpl[] = "/tmp/adacpp_glbst_XXXXXX";
-    char *dir = ::mkdtemp(tmpl);
+    std::string tmpl = adacpp::temp_template("adacpp_glbst");
+    char *dir = ::mkdtemp(tmpl.data());
     if (!dir)
         return -1;
     long n = adacpp::step_to_glb_single(in_path, out_path, dir, deflection, angular_deg, meshopt);
@@ -1120,6 +1120,103 @@ std::vector<StepShapeData> read_step_shapes_impl(nb::bytes data, const std::stri
         collect_step_shapes(st, ct, free_shapes.Value(i), TopLoc_Location(), out);
     }
     return out;
+}
+
+// STEP bytes -> GLB bytes in one pass, keeping the OCAF document intact end to end.
+//
+// The colour-preserving counterpart to read_step_bytes + write_glb_bytes, which lose it twice over:
+// read_step_bytes uses the plain STEPControl_Reader (no XCAF layer, so STYLED_ITEM is never even
+// looked at) and fuses everything via OneShape(); write_glb_bytes then builds an empty document with
+// no ColorTool. The result is a GLB with zero materials, which a viewer renders in its own default
+// grey. Handing RWGltf the document STEPCAFControl_Reader produced keeps the names, the assembly
+// tree, and both solid-level and per-face colours, without flattening to a shape list (a flat list
+// re-emits a solid AND each of its faces, duplicating the geometry).
+nb::bytes step_bytes_to_glb_bytes_impl(nb::bytes data, double linear_deflection, double angular_deg,
+                                       const std::string &unit) {
+    if (linear_deflection <= 0.0)
+        linear_deflection = 0.1;
+    // Restore the caller's value on exit — "xstep.cascade.unit" is a process-global
+    // Interface_Static parameter; leaving it set leaks into later reads.
+    const InterfaceStaticCValGuard cascade_unit_guard("xstep.cascade.unit");
+
+    const std::filesystem::path tmp_in = make_temp_path("adacpp_step_glb_in", ".stp");
+    {
+        std::ofstream f(tmp_in.string(), std::ios::binary);
+        f.write(data.c_str(), static_cast<std::streamsize>(data.size()));
+    }
+
+    Handle(TDocStd_Document) doc = new TDocStd_Document(TCollection_ExtendedString("MDTV-XCAF"));
+    {
+        STEPCAFControl_Reader reader;
+        reader.SetColorMode(Standard_True);
+        reader.SetNameMode(Standard_True);
+        reader.SetLayerMode(Standard_True);
+        // Set AFTER constructing the reader (its ctor resets the static), before ReadFile —
+        // same order as read_step_shapes / StepStore.create_step_reader.
+        Interface_Static::SetCVal("xstep.cascade.unit", unit.c_str());
+        const IFSelect_ReturnStatus st = reader.ReadFile(tmp_in.string().c_str());
+        if (st != IFSelect_RetDone) {
+            std::error_code ec;
+            std::filesystem::remove(tmp_in, ec);
+            throw std::runtime_error("step_bytes_to_glb_bytes: STEPCAFControl_Reader could not parse the input");
+        }
+        if (!reader.Transfer(doc)) {
+            std::error_code ec;
+            std::filesystem::remove(tmp_in, ec);
+            throw std::runtime_error("step_bytes_to_glb_bytes: transfer to OCAF document failed");
+        }
+    }
+    std::error_code ec_in;
+    std::filesystem::remove(tmp_in, ec_in);
+
+    // RWGltf needs a triangulation per face; mesh every shape the document holds.
+    Handle(XCAFDoc_ShapeTool) shapeTool = XCAFDoc_DocumentTool::ShapeTool(doc->Main());
+    TDF_LabelSequence labels;
+    shapeTool->GetFreeShapes(labels);
+    for (int i = 1; i <= labels.Length(); ++i) {
+        const TopoDS_Shape shape = shapeTool->GetShape(labels.Value(i));
+        if (shape.IsNull())
+            continue;
+        // MSVC only defines M_PI under _USE_MATH_DEFINES; spell the conversion out.
+        constexpr double deg2rad = 3.14159265358979323846 / 180.0;
+        BRepMesh_IncrementalMesh(shape, linear_deflection,
+                                 /*relative=*/Standard_False, angular_deg * deg2rad,
+                                 /*parallel=*/Standard_True);
+    }
+
+    const std::filesystem::path tmp = make_temp_path("adacpp_glb", ".glb");
+    const std::string tmpname = tmp.string();
+    {
+        RWGltf_CafWriter writer(TCollection_AsciiString(tmpname.c_str()), /*isBinary=*/Standard_True);
+        // Same Z-up + compact-transform configuration as write_glb_bytes, so both writers
+        // land in the adapy viewer's orientation.
+        writer.ChangeCoordinateSystemConverter().SetInputCoordinateSystem(RWMesh_CoordinateSystem_Zup);
+        writer.SetTransformationFormat(RWGltf_WriterTrsfFormat_Compact);
+        TColStd_IndexedDataMapOfStringString fileInfo;
+        fileInfo.Add(TCollection_AsciiString("Authors"), TCollection_AsciiString("adacpp"));
+        const Message_ProgressRange progress;
+        if (!writer.Perform(doc, fileInfo, progress)) {
+            std::error_code ec;
+            std::filesystem::remove(tmp, ec);
+            throw std::runtime_error("step_bytes_to_glb_bytes: RWGltf_CafWriter::Perform failed");
+        }
+    }
+
+    std::ifstream f(tmpname, std::ios::binary | std::ios::ate);
+    if (!f.is_open()) {
+        std::error_code ec;
+        std::filesystem::remove(tmp, ec);
+        throw std::runtime_error("step_bytes_to_glb_bytes: failed to re-open temp file");
+    }
+    const auto size = static_cast<std::size_t>(f.tellg());
+    f.seekg(0, std::ios::beg);
+    std::vector<char> buffer(size);
+    if (size > 0)
+        f.read(buffer.data(), size);
+    f.close();
+    std::error_code ec;
+    std::filesystem::remove(tmp, ec);
+    return nb::bytes(buffer.data(), buffer.size());
 }
 
 nb::bytes write_glb_bytes_impl(const ShapeHandle &sh, double linear_deflection) {
@@ -3213,8 +3310,8 @@ static adacpp::ifc_emit::FileStats write_ifc_file_parallel_impl(const std::strin
     if (nth > (int) roots.size())
         nth = std::max(1, (int) roots.size());
 
-    char tmpl[] = "/tmp/adacpp_ifc_XXXXXX";
-    char *dir = ::mkdtemp(tmpl);
+    std::string tmpl = adacpp::temp_template("adacpp_ifc");
+    char *dir = ::mkdtemp(tmpl.data());
     if (!dir)
         return fs;
     std::string tdir = dir;
@@ -3394,8 +3491,8 @@ static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_pa
     int nth = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
     if (nth > (int) roots.size())
         nth = std::max(1, (int) roots.size());
-    char tmpl[] = "/tmp/adacpp_stp_XXXXXX";
-    char *dir = ::mkdtemp(tmpl);
+    std::string tmpl = adacpp::temp_template("adacpp_stp");
+    char *dir = ::mkdtemp(tmpl.data());
     if (!dir)
         return fs;
     std::string tdir = dir;
@@ -4232,7 +4329,18 @@ void cad_module(nb::module_ &m) {
 
     m.def("write_glb_bytes", &write_glb_bytes_impl, "shape"_a, "linear_deflection"_a = 0.1,
           "Tessellate a ShapeHandle and write a binary glTF (.glb) into "
-          "a bytes buffer. linear_deflection<=0 falls back to 0.1.");
+          "a bytes buffer. linear_deflection<=0 falls back to 0.1. NOTE: a bare ShapeHandle "
+          "carries no colour, so the GLB has NO materials — for STEP input use "
+          "step_bytes_to_glb_bytes, which keeps the file's colours.");
+
+    m.def("step_bytes_to_glb_bytes", &step_bytes_to_glb_bytes_impl, "data"_a, "linear_deflection"_a = 0.1,
+          "angular_deg"_a = 20.0, "unit"_a = "M",
+          "STEP (bytes) -> binary glTF (.glb) (bytes) in one pass via OCAF, keeping the file's "
+          "names, assembly tree and colours (both solid-level and per-face) in the GLB's "
+          "materials. This is the colour-preserving replacement for read_step_bytes + "
+          "write_glb_bytes, which between them drop every colour (plain STEPControl_Reader has no "
+          "XCAF layer; the writer builds a document with no ColorTool) and yield a materialless, "
+          "uniformly grey model. Converts the file's length unit to `unit` (default M).");
 
     // --- shape-algebra verbs (mirror adapy's CadBackend) ---
 

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -4147,16 +4147,21 @@ void cad_module(nb::module_ &m) {
                 d["description"] = t.description;
                 d["watertight"] = t.watertight;
                 d["default"] = t.is_default;
+                d["neutral"] = t.neutral;
                 out.append(d);
             }
             return out;
         },
         "Enumerate the tessellation tracks THIS BUILD provides: a list of dicts with name, label, "
-        "description, watertight, default. `name` is the token to pass back as the `pipeline` "
-        "argument of stream_step_to_glb / tessellate_stream.\n\n"
+        "description, watertight, default, neutral. `name` is the token to pass back as the "
+        "`pipeline` argument of stream_step_to_glb / tessellate_stream.\n\n"
         "This is the single source of truth for the track vocabulary: callers must NOT hardcode it. "
         "The list reflects what is actually compiled in (the taxonomy kernels are absent from the "
-        "wasm build), so it answers 'what can I run here?', not 'what exists in principle'.");
+        "wasm build), so it answers 'what can I run here?', not 'what exists in principle'.\n\n"
+        "`neutral` says whether the track meshes NEUTRAL surfaces — the OCC-free path fed by the "
+        "native STEP/IFC readers and the NGEOM wire. The taxonomy tracks (occ/cgal/hybrid) are not "
+        "neutral: on that path they silently mesh as if no track were selected rather than "
+        "erroring, so a caller offering a track choice for a neutral path must filter on this.");
 
     m.def(
         "ifc_taxonomy_settings",

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -789,9 +789,10 @@ Mesh stream_step_to_meshes_impl(const std::string &path, const std::string &pipe
 // now lives in step_to_glb_stream.h (adacpp::stream_step_to_glb) so the standalone OCC-free STP2GLB
 // CLI can reuse it without nanobind/OCCT. This thin wrapper keeps the existing python binding.
 int stream_step_to_glb_impl(const std::string &in_path, const std::string &out_path, double deflection,
-                            double angular_deg, int num_threads, bool meshopt, double model_scale, bool face_regions) {
+                            double angular_deg, int num_threads, bool meshopt, double model_scale, bool face_regions,
+                            const std::string &pipeline, bool pin_boundary) {
     return (int) adacpp::stream_step_to_glb(in_path, out_path, deflection, angular_deg, num_threads, meshopt,
-                                            /*spill_dir=*/"", model_scale, face_regions);
+                                            /*spill_dir=*/"", model_scale, face_regions, pipeline, pin_boundary);
 }
 
 // Native OCC-free IFC -> GLB (IfcResolver: geometry + colour + spatial tree, baked to metres).
@@ -4057,14 +4058,18 @@ void cad_module(nb::module_ &m) {
 
     m.def("stream_step_to_glb", &stream_step_to_glb_impl, "in_path"_a, "out_path"_a, "deflection"_a = 0.0,
           "angular_deg"_a = 20.0, "num_threads"_a = 0, "meshopt"_a = true, "model_scale"_a = 0.0,
-          "face_regions"_a = false,
+          "face_regions"_a = false, "pipeline"_a = "libtess2", "pin_boundary"_a = true,
           "Native STEP -> GLB file: stream the .stp with the native reader (offset index + per-statement "
           "pread, bounded memory), tessellate each solid across num_threads worker threads (0 = auto = "
           "hardware_concurrency clamped to the cgroup cpu quota), each owning a spill lane joined at the "
           "end, bake world transform(s) + "
           "colour, and write a merge-by-colour GLB matching the adapy viewer's structure. meshopt=true "
           "(default) bakes EXT_meshopt_compression inline (no Python re-pack). Returns the number of "
-          "solids written (-1 on I/O error). angular_deg in degrees.");
+          "solids written (-1 on I/O error, and likewise on an unknown pipeline name). angular_deg in "
+          "degrees. pipeline selects the tessellation track by name (see tess_tracks(); '' / 'libtess2' "
+          "= default, 'cdt' = watertight); pin_boundary is a libtess2-track option. The threaded core "
+          "has taken both since the track vocabulary landed — this binding simply never forwarded them, "
+          "so every native conversion silently ran libtess2 no matter what the caller selected.");
 
     m.def("stream_ifc_to_glb", &stream_ifc_to_glb_impl, "in_path"_a, "out_path"_a, "deflection"_a = 0.0,
           "angular_deg"_a = 20.0, "meshopt"_a = true, "model_scale"_a = 0.0, "num_threads"_a = 0,

--- a/src/cad/ifc_to_glb_stream.h
+++ b/src/cad/ifc_to_glb_stream.h
@@ -211,9 +211,15 @@ inline long stream_ifc_to_glb(const std::string &in_path, const std::string &out
     }
     if (remove_after)
         ::rmdir(spill.c_str());
-    if (std::uint64_t dropped = adacpp::ngeom::tess_dropped_faces())
-        std::fprintf(stderr, "[GEOMHEALTH-JSON] {\"dropped_faces\":%llu,\"total_faces\":%llu}\n",
-                     (unsigned long long) dropped, (unsigned long long) adacpp::ngeom::tess_total_faces());
+    {
+        std::uint64_t dropped = adacpp::ngeom::tess_dropped_faces();
+        std::uint64_t suspect = adacpp::ngeom::tess_suspect_faces();
+        if (dropped || suspect)
+            std::fprintf(stderr,
+                         "[GEOMHEALTH-JSON] {\"dropped_faces\":%llu,\"suspect_faces\":%llu,\"total_faces\":%llu}\n",
+                         (unsigned long long) dropped, (unsigned long long) suspect,
+                         (unsigned long long) adacpp::ngeom::tess_total_faces());
+    }
     return ok ? nwritten.load() : -1;
 }
 

--- a/src/cad/ifc_to_glb_stream.h
+++ b/src/cad/ifc_to_glb_stream.h
@@ -98,9 +98,9 @@ inline long stream_ifc_to_glb(const std::string &in_path, const std::string &out
     // Spill dir: private mkdtemp (auto-removed) unless the caller supplied one.
     std::string spill;
     bool remove_after = false;
-    char tmpl[] = "/tmp/adacpp_ifcglb_XXXXXX";
+    std::string tmpl = adacpp::temp_template("adacpp_ifcglb");
     if (spill_dir.empty()) {
-        if (char *dir = ::mkdtemp(tmpl)) {
+        if (char *dir = ::mkdtemp(tmpl.data())) {
             spill = dir;
             remove_after = true;
         }

--- a/src/cad/ifc_to_glb_stream.h
+++ b/src/cad/ifc_to_glb_stream.h
@@ -34,9 +34,15 @@
 
 namespace adacpp {
 
+// `pipeline` / `face_regions` / `pin_boundary` mean exactly what they do on stream_step_to_glb, and
+// for the same reason: both converters feed the SAME neutral tessellator (TessParams) and the SAME
+// GLB writer (ngeom_glb.h). Neither is a STEP feature — the track vocabulary and per-face region
+// capture live in the ngeom layer, so the only thing that ever made them STEP-only was this
+// function not forwarding them.
 inline long stream_ifc_to_glb(const std::string &in_path, const std::string &out_path, double deflection,
                               double angular_deg, bool meshopt, const std::string &spill_dir = "",
-                              double model_scale = 0.0, int num_threads = 0) {
+                              double model_scale = 0.0, int num_threads = 0, const std::string &pipeline = "",
+                              bool face_regions = false, bool pin_boundary = true) {
     using namespace adacpp::ngeom;
     adacpp::tune_malloc_for_streaming();
     adacpp::ngeom::reset_tess_face_stats(); // count dropped faces (audit health flag)
@@ -49,7 +55,15 @@ inline long stream_ifc_to_glb(const std::string &in_path, const std::string &out
     std::vector<long> roots = master.proxy_roots();
     const double usc = master.unit_scale(); // metres per file length-unit -> bake to metres
 
+    // Unknown track => -1, never a silent fallback: a caller asking for a track that doesn't exist
+    // wants to know, not to get different geometry than it asked for (same contract as STEP's).
+    auto track = parse_track(pipeline);
+    if (!track)
+        return -1;
     TessParams tp;
+    tp.track = *track;
+    tp.libtess2.pin_boundary = pin_boundary;
+    tp.capture_face_ranges = face_regions; // opt-in per-face clickable regions -> scenes[0].extras
     tp.deflection = deflection;
     tp.max_angle = angular_deg * PI / 180.0;
     tp.threads = 1;
@@ -124,6 +138,13 @@ inline long stream_ifc_to_glb(const std::string &in_path, const std::string &out
             adacpp::glb::GlbSolid gs;
             gs.positions = std::move(tm.positions);
             gs.indices = std::move(tm.indices);
+            // Carry per-face clickable regions (relative to this product's index buffer) when
+            // captured — mirrors stream_step_to_glb. Capturing them in TessParams is not enough:
+            // the writer reads them off GlbSolid, so without this the flag would cost the serial
+            // face path and emit nothing.
+            gs.face_ranges.reserve(tm.face_ranges.size());
+            for (const auto &fr : tm.face_ranges)
+                gs.face_ranges.push_back({fr.first_index, fr.index_count, fr.face_id, fr.face_seq});
             gs.color = {rr.cr, rr.cg, rr.cb, rr.ca}; // grey default when !has_color
             gs.transforms = rr.transforms;
             gs.id = rr.id;

--- a/src/cad/posix_compat.h
+++ b/src/cad/posix_compat.h
@@ -27,6 +27,7 @@
 #include <io.h>
 #include <mutex>
 #include <share.h>
+#include <string>
 #include <sys/stat.h>
 #include <unordered_map>
 
@@ -114,13 +115,33 @@ inline int msync(void *addr, size_t length, int) {
     return FlushViewOfFile(addr, length) ? 0 : -1; // flush a writable mapping to disk
 }
 
+// Windows has no /tmp. The native readers hardcode "/tmp/foo_XXXXXX" templates (fine on Linux/wasm);
+// on Windows MSVC resolves "/tmp" to "C:\tmp", which usually doesn't exist, so _mkdir fails and the
+// whole conversion returns -1. Redirect a leading "/tmp/" to the process temp dir (GetTempPathA) so
+// the same hardcoded templates land under a real directory. Callers use mkdtemp's RETURN value (not
+// the passed template), so returning a shim-owned buffer with the longer real path is safe even
+// though it no longer aliases `tmpl`.
+inline std::string _win_tmp_redirect(const char *tmpl) {
+    if (std::strncmp(tmpl, "/tmp/", 5) == 0) {
+        char buf[MAX_PATH];
+        const DWORD n = GetTempPathA(MAX_PATH, buf); // includes a trailing backslash
+        if (n > 0 && n < MAX_PATH)
+            return std::string(buf, n) + (tmpl + 5);
+    }
+    return std::string(tmpl);
+}
+
 inline char *mkdtemp(char *tmpl) {
     // tmpl ends in "XXXXXX"; make it unique then create the directory (POSIX mkdtemp semantics).
-    if (_mktemp_s(tmpl, std::strlen(tmpl) + 1) != 0)
+    // A thread_local buffer holds the /tmp-redirected path so the returned pointer stays valid until
+    // this thread's next mkdtemp call — long enough for the caller to copy it into a std::string.
+    thread_local std::string path;
+    path = _win_tmp_redirect(tmpl);
+    if (_mktemp_s(path.data(), path.size() + 1) != 0) // data() buffer spans size()+1 (incl. NUL)
         return nullptr;
-    if (_mkdir(tmpl) != 0)
+    if (_mkdir(path.c_str()) != 0)
         return nullptr;
-    return tmpl;
+    return path.data();
 }
 inline int ftruncate(int fd, long long length) {
     return _chsize_s(fd, length);
@@ -146,3 +167,39 @@ inline int setenv(const char *name, const char *value, int /*overwrite*/) {
     return _putenv_s(name, value); // _putenv_s always overwrites
 }
 #endif
+
+#include <cstdlib>
+#include <string>
+
+namespace adacpp {
+// Base directory for the readers' scratch files/dirs. An explicit override lets a caller redirect
+// every hardcoded temp location without touching source (e.g. a sandbox with no writable /tmp, or a
+// fast local SSD for spill): $ADACPP_TMPDIR wins, then $TMPDIR, else the platform default (%TEMP%
+// via GetTempPath on Windows, /tmp elsewhere). Never returns a trailing separator.
+inline std::string temp_base_dir() {
+    if (const char *e = std::getenv("ADACPP_TMPDIR"); e && *e)
+        return std::string(e);
+    if (const char *e = std::getenv("TMPDIR"); e && *e)
+        return std::string(e);
+#if defined(_WIN32)
+    char buf[MAX_PATH];
+    const DWORD n = GetTempPathA(MAX_PATH, buf); // ends with a backslash
+    if (n > 0 && n < MAX_PATH) {
+        std::string s(buf, n);
+        while (!s.empty() && (s.back() == '\\' || s.back() == '/'))
+            s.pop_back();
+        return s;
+    }
+    return "."; // last resort: process cwd
+#else
+    return "/tmp";
+#endif
+}
+
+// A mutable mkdtemp/mkstemp template "<temp_base_dir>/<name>_XXXXXX". Returned by value; pass
+// .data() to mkdtemp/mkstemp (they rewrite the XXXXXX in place). Replaces the old hardcoded
+// "/tmp/..._XXXXXX" literals so the override above reaches every scratch path.
+inline std::string temp_template(const char *name) {
+    return temp_base_dir() + "/" + name + "_XXXXXX";
+}
+} // namespace adacpp

--- a/src/cad/step_to_glb_stream.h
+++ b/src/cad/step_to_glb_stream.h
@@ -143,9 +143,9 @@ inline long stream_step_to_glb(const std::string &in_path, const std::string &ou
     // otherwise the caller's directory (created if missing, left in place afterwards).
     std::string spill;
     bool remove_after = false;
-    char tmpl[] = "/tmp/adacpp_glb_XXXXXX";
+    std::string tmpl = adacpp::temp_template("adacpp_glb");
     if (spill_dir.empty()) {
-        if (char *dir = ::mkdtemp(tmpl)) { // unique spill dir (removed after assembly)
+        if (char *dir = ::mkdtemp(tmpl.data())) { // unique spill dir (removed after assembly)
             spill = dir;
             remove_after = true;
         }

--- a/src/cad/step_to_glb_stream.h
+++ b/src/cad/step_to_glb_stream.h
@@ -303,9 +303,15 @@ inline long stream_step_to_glb(const std::string &in_path, const std::string &ou
     prof.note("threads", nthreads);
     // Emit a health line the worker folds into the audit (convert_meta) so silently-dropped faces are
     // flagged without visual inspection. Only when something dropped — keep the common case quiet.
-    if (std::uint64_t dropped = adacpp::ngeom::tess_dropped_faces())
-        std::fprintf(stderr, "[GEOMHEALTH-JSON] {\"dropped_faces\":%llu,\"total_faces\":%llu}\n",
-                     (unsigned long long) dropped, (unsigned long long) adacpp::ngeom::tess_total_faces());
+    {
+        std::uint64_t dropped = adacpp::ngeom::tess_dropped_faces();
+        std::uint64_t suspect = adacpp::ngeom::tess_suspect_faces();
+        if (dropped || suspect)
+            std::fprintf(stderr,
+                         "[GEOMHEALTH-JSON] {\"dropped_faces\":%llu,\"suspect_faces\":%llu,\"total_faces\":%llu}\n",
+                         (unsigned long long) dropped, (unsigned long long) suspect,
+                         (unsigned long long) adacpp::ngeom::tess_total_faces());
+    }
     return ok ? nwritten.load() : -1;
 }
 

--- a/src/cad/step_to_glb_stream.h
+++ b/src/cad/step_to_glb_stream.h
@@ -193,8 +193,8 @@ inline long stream_step_to_glb(const std::string &in_path, const std::string &ou
                 // Carry per-face clickable regions (relative to this solid's index buffer) when captured.
                 gs.face_ranges.reserve(tm.face_ranges.size());
                 for (const auto &fr : tm.face_ranges)
-                    gs.face_ranges.push_back({fr.first_index, fr.index_count, fr.face_id, fr.face_seq,
-                                              fr.has_color, fr.cr, fr.cg, fr.cb, fr.ca});
+                    gs.face_ranges.push_back({fr.first_index, fr.index_count, fr.face_id, fr.face_seq, fr.has_color,
+                                              fr.cr, fr.cg, fr.cb, fr.ca});
                 gs.color = {rr.cr, rr.cg, rr.cb, rr.ca}; // grey default when !has_color
                 gs.transforms = rr.transforms;
                 gs.id = rr.id; // fallback leaf name

--- a/src/cad/step_to_glb_stream.h
+++ b/src/cad/step_to_glb_stream.h
@@ -193,7 +193,8 @@ inline long stream_step_to_glb(const std::string &in_path, const std::string &ou
                 // Carry per-face clickable regions (relative to this solid's index buffer) when captured.
                 gs.face_ranges.reserve(tm.face_ranges.size());
                 for (const auto &fr : tm.face_ranges)
-                    gs.face_ranges.push_back({fr.first_index, fr.index_count, fr.face_id, fr.face_seq});
+                    gs.face_ranges.push_back({fr.first_index, fr.index_count, fr.face_id, fr.face_seq,
+                                              fr.has_color, fr.cr, fr.cg, fr.cb, fr.ca});
                 gs.color = {rr.cr, rr.cg, rr.cb, rr.ca}; // grey default when !has_color
                 gs.transforms = rr.transforms;
                 gs.id = rr.id; // fallback leaf name
@@ -219,7 +220,10 @@ inline long stream_step_to_glb(const std::string &in_path, const std::string &ou
                         M[14] *= s;
                     }
                 }
-                lane.add(gs); // spilled to disk immediately
+                // A solid whose faces carry distinct per-face colours (AP214 per-face styling) is split
+                // into one primitive/material per colour; single-colour solids pass through unchanged.
+                for (adacpp::glb::GlbSolid &part : adacpp::glb::split_solid_by_face_colour(gs))
+                    lane.add(part); // spilled to disk immediately
                 nwritten.fetch_add(1, std::memory_order_relaxed);
             };
             // Phase A — the huge prefix, one root at a time BEFORE the pool starts: every thread

--- a/src/cad/step_to_mesh_stream.h
+++ b/src/cad/step_to_mesh_stream.h
@@ -373,9 +373,15 @@ inline long stream_step_to_mesh(const std::string &in_path, const std::string &o
     if (remove_after)
         ::rmdir(spill.c_str());
     prof.note("threads", nthreads);
-    if (std::uint64_t dropped = adacpp::ngeom::tess_dropped_faces())
-        std::fprintf(stderr, "[GEOMHEALTH-JSON] {\"dropped_faces\":%llu,\"total_faces\":%llu}\n",
-                     (unsigned long long) dropped, (unsigned long long) adacpp::ngeom::tess_total_faces());
+    {
+        std::uint64_t dropped = adacpp::ngeom::tess_dropped_faces();
+        std::uint64_t suspect = adacpp::ngeom::tess_suspect_faces();
+        if (dropped || suspect)
+            std::fprintf(stderr,
+                         "[GEOMHEALTH-JSON] {\"dropped_faces\":%llu,\"suspect_faces\":%llu,\"total_faces\":%llu}\n",
+                         (unsigned long long) dropped, (unsigned long long) suspect,
+                         (unsigned long long) adacpp::ngeom::tess_total_faces());
+    }
     return ok ? (long) total : -1;
 }
 

--- a/src/cad/step_to_mesh_stream.h
+++ b/src/cad/step_to_mesh_stream.h
@@ -210,9 +210,9 @@ inline long stream_step_to_mesh(const std::string &in_path, const std::string &o
 
     std::string spill;
     bool remove_after = false;
-    char tmpl[] = "/tmp/adacpp_mesh_XXXXXX";
+    std::string tmpl = adacpp::temp_template("adacpp_mesh");
     if (spill_dir.empty()) {
-        if (char *dir = ::mkdtemp(tmpl)) {
+        if (char *dir = ::mkdtemp(tmpl.data())) {
             spill = dir;
             remove_after = true;
         }

--- a/src/cadit/step/step_reader.h
+++ b/src/cadit/step/step_reader.h
@@ -1036,6 +1036,11 @@ private:
     static bool enum_true(const Value &v) {
         return !(v.kind == Kind::Enum && v.s == "F");
     }
+    // Closed/periodic flag: true ONLY when the enum is explicitly .T. (.F./.U./missing -> not closed).
+    // Conservative on purpose — a spurious "closed" would send an open patch down the periodic seam path.
+    static bool enum_flag_true(const Value &v) {
+        return v.kind == Kind::Enum && v.s == "T";
+    }
 
     static ng::Vec3 vec3_of(const Value &list) {
         ng::Vec3 r{0, 0, 0};
@@ -1243,14 +1248,20 @@ private:
     }
 
     // Build a BSplineSurface from raw Part-21 args (grid = list of u-rows of control-point refs;
-    // optional weights = same-shaped grid of reals). u_closed/v_closed are left default, matching
-    // ngeom_decode.h (which reads but ignores them).
+    // optional weights = same-shaped grid of reals). u_closed/v_closed (the B_SPLINE_SURFACE Part-21
+    // enum flags) MUST be honoured: a closed/periodic surface (e.g. a hose, whose u knot vector is
+    // non-clamped with end multiplicity < degree+1) covers a full u/v period, so the tessellator has
+    // to unwrap the seam. Dropping them routes the face through the generic (non-periodic) path, which
+    // tears the tube at the u=umin/umax seam. See ngeom_bspline.h BSplineSurface::point (period wrap).
     std::shared_ptr<ng::Surface> build_bspline_surface(long u_deg, long v_deg, const Value &grid, const Value &u_mults,
                                                        const Value &v_mults, const Value &u_knots, const Value &v_knots,
-                                                       const Value *weights) {
+                                                       const Value *weights, bool u_closed = false,
+                                                       bool v_closed = false) {
         auto s = std::make_shared<ng::BSplineSurface>();
         s->u_degree = (int) u_deg;
         s->v_degree = (int) v_deg;
+        s->u_closed = u_closed;
+        s->v_closed = v_closed;
         if (grid.kind != Kind::List || grid.items.empty())
             return s;
         s->nu = (int) grid.items.size();
@@ -1288,8 +1299,12 @@ private:
         const auto *rat = sub(in, "RATIONAL_B_SPLINE_SURFACE");
         if (!bs || !bk || bs->size() < 3 || bk->size() < 4)
             return nullptr;
+        // B_SPLINE_SURFACE sub-args (no leading name): 0=u_deg,1=v_deg,2=grid,3=surface_form,
+        // 4=u_closed,5=v_closed,6=self_intersect.
+        bool u_closed = bs->size() > 4 && enum_flag_true((*bs)[4]);
+        bool v_closed = bs->size() > 5 && enum_flag_true((*bs)[5]);
         return build_bspline_surface((*bs)[0].i, (*bs)[1].i, (*bs)[2], (*bk)[0], (*bk)[1], (*bk)[2], (*bk)[3],
-                                     (rat && !rat->empty()) ? &(*rat)[0] : nullptr);
+                                     (rat && !rat->empty()) ? &(*rat)[0] : nullptr, u_closed, v_closed);
     }
     std::shared_ptr<ng::Curve> bspline_curve_complex(const Instance *in) {
         const auto *bc = sub(in, "B_SPLINE_CURVE");
@@ -1333,8 +1348,11 @@ private:
         } else if (in) {
             std::string_view t = in->type;
             if (t == "B_SPLINE_SURFACE_WITH_KNOTS" && in->args.size() >= 12)
+                // args: 0=name,1=u_deg,2=v_deg,3=grid,4=form,5=u_closed,6=v_closed,7=self_int,
+                // 8=u_mults,9=v_mults,10=u_knots,11=v_knots.
                 s = build_bspline_surface(in->args[1].i, in->args[2].i, in->args[3], in->args[8], in->args[9],
-                                          in->args[10], in->args[11], nullptr);
+                                          in->args[10], in->args[11], nullptr, enum_flag_true(in->args[5]),
+                                          enum_flag_true(in->args[6]));
             else if (t == "SURFACE_OF_LINEAR_EXTRUSION" && in->args.size() >= 3 && in->args[1].is_ref() &&
                      in->args[2].is_ref()) {
                 // SURFACE_OF_LINEAR_EXTRUSION('',#swept_curve,#VECTOR('',#dir,depth))

--- a/src/cadit/step/step_reader.h
+++ b/src/cadit/step/step_reader.h
@@ -596,7 +596,11 @@ private:
             t == "EXTRUDED_AREA_SOLID" || t == "REVOLVED_AREA_SOLID" || t == "SWEPT_DISK_SOLID" ||
             t == "BOOLEAN_RESULT")
             lists.roots.push_back(id);
-        else if (t == "STYLED_ITEM")
+        else if (t == "STYLED_ITEM" || t == "OVER_RIDING_STYLED_ITEM")
+            // OVER_RIDING_STYLED_ITEM is a STYLED_ITEM subtype (extra 4th over-ridden-style arg,
+            // harmlessly ignored by build_colour_map). AP214 per-face styling emits it in bulk
+            // (this robot file: 33 STYLED_ITEM + 3748 OVER_RIDING_STYLED_ITEM), so dropping it here
+            // discarded 99% of the presentation colours.
             lists.styled.push_back(id);
         else if (t == "ADVANCED_BREP_SHAPE_REPRESENTATION" || t == "SHAPE_REPRESENTATION" ||
                  t == "MANIFOLD_SURFACE_SHAPE_REPRESENTATION" || t == "FACETED_BREP_SHAPE_REPRESENTATION" ||
@@ -936,7 +940,8 @@ private:
             if (t == "MANIFOLD_SOLID_BREP" || t == "SHELL_BASED_SURFACE_MODEL" || t == "EXTRUDED_AREA_SOLID" ||
                 t == "REVOLVED_AREA_SOLID" || t == "SWEPT_DISK_SOLID")
                 tl.roots.push_back(id);
-            else if (t == "STYLED_ITEM")
+            else if (t == "STYLED_ITEM" || t == "OVER_RIDING_STYLED_ITEM")
+                // See the streaming classifier: OVER_RIDING_STYLED_ITEM is the per-face styling subtype.
                 tl.styled.push_back(id);
             else if (t == "ADVANCED_BREP_SHAPE_REPRESENTATION" || t == "SHAPE_REPRESENTATION" ||
                      t == "MANIFOLD_SURFACE_SHAPE_REPRESENTATION" || t == "FACETED_BREP_SHAPE_REPRESENTATION" ||
@@ -1533,6 +1538,16 @@ private:
             return c->second;
         auto f = std::make_shared<ng::FaceSurfaceN>();
         f->src_id = id; // STEP ADVANCED_FACE / FACE_SURFACE entity id -> per-face clickable region label
+        // Per-face colour: AP214 OVER_RIDING_STYLED_ITEM styles target the ADVANCED_FACE #id (this face),
+        // so build_colour_map keys colour_map_ by face id for those. Stamp it here; the per-solid lookup
+        // in resolve_root (colour_map_[solid id]) remains the base/fallback for un-styled faces.
+        if (auto cit = colour_map_.find(id); cit != colour_map_.end()) {
+            f->has_color = true;
+            f->cr = cit->second.r;
+            f->cg = cit->second.g;
+            f->cb = cit->second.b;
+            f->ca = cit->second.a;
+        }
         const Instance *in = inst(id);
         if (in && (in->type == "ADVANCED_FACE" || in->type == "FACE_SURFACE") && in->args.size() >= 4) {
             if (in->args[1].kind == Kind::List)

--- a/src/diff/glb_diff_native.h
+++ b/src/diff/glb_diff_native.h
@@ -97,11 +97,11 @@ inline std::shared_ptr<DiskBuf> decode_to_disk(const unsigned char *enc, size_t 
     size_t dsize = count * stride;
     if (dsize == 0)
         return nullptr;
-    char tmpl[] = "/tmp/adacpp_diffdec_XXXXXX";
-    int fd = ::mkstemp(tmpl);
+    std::string tmpl = adacpp::temp_template("adacpp_diffdec");
+    int fd = ::mkstemp(tmpl.data());
     if (fd < 0)
         return nullptr;
-    ::unlink(tmpl); // disk space freed on close; no path left behind
+    ::unlink(tmpl.c_str()); // disk space freed on close; no path left behind
     auto db = std::make_shared<DiskBuf>();
     db->fd = fd;
     if (::ftruncate(fd, (off_t) dsize) != 0)

--- a/src/geom/neutral/ngeom_bspline.h
+++ b/src/geom/neutral/ngeom_bspline.h
@@ -212,12 +212,31 @@ struct BSplineSurface : Surface {
         vmax = Uv[nv];
     }
 
+    // Reduce a parameter into the knot domain [lo,hi]. A CLOSED/periodic direction repeats with
+    // period (hi-lo), so WRAP (fmod) rather than clamp: this makes evaluation continuous ACROSS the
+    // u=umin/umax seam. The periodic tessellation paths (tessellate_periodic_band / _winding) place
+    // sample points a little past the seam (u in [seam, seam+period]); clamping would pin every
+    // over-the-seam point onto the umax edge and tear the tube, whereas wrapping lands them back on
+    // the real periodic geometry (S(umax)==S(umin) for a closed surface). An OPEN direction still
+    // clamps, so a stray FD/Newton probe past the end returns the boundary point, not an extrapolation.
+    static double reduce_param(double t, double lo, double hi, bool closed) {
+        if (closed) {
+            double span = hi - lo;
+            if (span > 1e-300) {
+                double r = std::fmod(t - lo, span);
+                if (r < 0.0)
+                    r += span;
+                return lo + r;
+            }
+        }
+        return clampd(t, lo, hi);
+    }
+
     Vec3 point(double u, double v) const override {
         using namespace bspline_detail;
-        // clamp to the knot domain (Rust BSplineSurface::point) — return the boundary point
-        // rather than extrapolating when a FD/Newton probe steps just outside.
-        u = clampd(u, Uu[u_degree], Uu[nu]);
-        v = clampd(v, Uv[v_degree], Uv[nv]);
+        // Reduce into the knot domain: wrap a closed/periodic direction (seam-continuous), else clamp.
+        u = reduce_param(u, Uu[u_degree], Uu[nu], u_closed);
+        v = reduce_param(v, Uv[v_degree], Uv[nv], v_closed);
         int su = find_span(nu - 1, u_degree, u, Uu);
         int sv = find_span(nv - 1, v_degree, v, Uv);
         if (u_degree <= kDeBoorMaxDeg && v_degree <= kDeBoorMaxDeg) {

--- a/src/geom/neutral/ngeom_bspline.h
+++ b/src/geom/neutral/ngeom_bspline.h
@@ -581,7 +581,52 @@ struct RevolutionSurface : Surface {
     bool uv(const Vec3 &p, double uhint, double vhint, double &u, double &v) const override {
         double umin, umax, vmin, vmax;
         domain(umin, umax, vmin, vmax);
-        return newton_uv(*this, p, umin, umax, vmin, vmax, uhint, vhint, u, v);
+        (void) vhint;
+        // Decoupled seed. The point's AXIAL position and RADIUS about the axis are invariant under
+        // the revolution, so v depends only on those — recover it by a 1D scan of the profile,
+        // independent of u; then u is simply the azimuth of p relative to profile(v) about the axis.
+        // The generic newton_uv's uniform 2D grid seed aliases against a wiggly high-degree profile
+        // (measured: 91% inversion failures on a degree-5 revolution -> a garbage UV boundary and
+        // holes in the tessellated face), so seed this way and only then Newton-refine.
+        Vec3 relp = p - axis_loc;
+        const double axial_p = axis_dir.dot(relp);
+        const Vec3 perp_p = relp - axis_dir * axial_p;
+        const double rad_p = perp_p.norm();
+        double bestv = vmin, bestd = 1e300;
+        const int NV = 128;
+        for (int j = 0; j <= NV; ++j) {
+            double vv = vmin + (vmax - vmin) * j / NV;
+            Vec3 c = profile->point(vv) - axis_loc;
+            double ax = axis_dir.dot(c);
+            double rd = (c - axis_dir * ax).norm();
+            double d = (ax - axial_p) * (ax - axial_p) + (rd - rad_p) * (rd - rad_p);
+            if (d < bestd) {
+                bestd = d;
+                bestv = vv;
+            }
+        }
+        // u is the azimuth of p relative to profile(bestv) about the axis — compute it directly from
+        // geometry. Do NOT seed u from the caller's uhint: on a face where earlier points fail to
+        // invert, the boundary loop's failure handler pins their u to the predecessor's, so the hint
+        // is a poisoned 0 that drags Newton into a v-boundary divergence.
+        double useed = 0.0;
+        Vec3 pc = profile->point(bestv) - axis_loc;
+        Vec3 perp_c = pc - axis_dir * axis_dir.dot(pc);
+        if (perp_c.norm() > 1e-9 && rad_p > 1e-9) {
+            Vec3 a = perp_c.normalized(), b = perp_p.normalized();
+            double ang = std::atan2(axis_dir.dot(a.cross(b)), clampd(a.dot(b), -1.0, 1.0));
+            useed = ang < 0 ? ang + TWO_PI : ang;
+        } else if (uhint == uhint && uhint >= umin && uhint <= umax) {
+            useed = uhint; // p sits on the axis (radius ~0): azimuth is undefined, fall back to the hint
+        }
+        newton_uv(*this, p, umin, umax, vmin, vmax, useed, bestv, u, v);
+        // Accept on a SCALE-RELATIVE residual, not newton_uv's absolute 1e-6 mm (a nanometre tolerance
+        // that a geometrically perfect inversion on a ~100 mm surface still "fails"). A finite-difference
+        // Jacobian over a wiggly high-degree profile converges to ~1e-5 of the surface radius; a genuine
+        // off-surface point is ~1e-1. Rejecting the former made the boundary loop's failure handler
+        // collapse ~90% of points onto their predecessor and tore holes in the face.
+        const double scale = std::max(relp.norm(), 1.0);
+        return (point(u, v) - p).norm() < 1e-3 * scale;
     }
     void periods(bool &up, double &uper, bool &vp, double &vper) const override {
         up = true;

--- a/src/geom/neutral/ngeom_decode.h
+++ b/src/geom/neutral/ngeom_decode.h
@@ -318,9 +318,9 @@ inline NgeomDoc decode(const uint8_t *data, size_t n) {
             auto s = std::make_shared<BSplineSurface>();
             s->u_degree = r.i32();
             s->v_degree = r.i32();
-            r.i32(); // u_closed
-            r.i32(); // v_closed
-            r.i32(); // self_intersect
+            s->u_closed = r.i32() != 0; // periodic in u: honoured for seam-continuous evaluation/tessellation
+            s->v_closed = r.i32() != 0; // periodic in v
+            r.i32();                    // self_intersect (unused for eval)
             s->nu = r.i32();
             s->nv = r.i32();
             int ncp = s->nu * s->nv;

--- a/src/geom/neutral/ngeom_glb.h
+++ b/src/geom/neutral/ngeom_glb.h
@@ -87,6 +87,15 @@ inline std::string fnum(double v) {
 inline uint32_t pad4(uint32_t n) {
     return (4 - (n & 3u)) & 3u;
 }
+// STEP COLOUR_RGB values are sRGB (display) colours, but glTF baseColorFactor is defined in LINEAR
+// space — so write the sRGB->linear transform, matching what OCC's XCAF does on import. Without it
+// the renderer treats the sRGB value as linear and its display gamma-encode lifts mid channels
+// (e.g. deep orange 0.4 -> ~0.67 green), yellowing the colour. Applied to RGB only, not alpha.
+inline float srgb_to_linear(float c) {
+    if (c <= 0.0f) return 0.0f;
+    if (c >= 1.0f) return 1.0f;
+    return c <= 0.04045f ? c / 12.92f : std::pow((c + 0.055f) / 1.055f, 2.4f);
+}
 
 constexpr float IDENT[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
 
@@ -269,8 +278,9 @@ inline bool glb_write_framed(const std::string &path, const std::vector<MatHeade
         meshes << (i ? "," : "") << "{\"name\":\"node" << i
                << "\",\"primitives\":[{\"attributes\":{\"POSITION\":" << i * 2 + 1 << "},\"indices\":" << i * 2
                << ",\"mode\":4,\"material\":" << i << "}]}";
-        materials << (i ? "," : "") << "{\"pbrMetallicRoughness\":{\"baseColorFactor\":[" << fnum(m.color[0]) << ","
-                  << fnum(m.color[1]) << "," << fnum(m.color[2]) << "," << fnum(m.color[3])
+        materials << (i ? "," : "") << "{\"pbrMetallicRoughness\":{\"baseColorFactor\":["
+                  << fnum(srgb_to_linear(m.color[0])) << "," << fnum(srgb_to_linear(m.color[1])) << ","
+                  << fnum(srgb_to_linear(m.color[2])) << "," << fnum(m.color[3])
                   << "],\"metallicFactor\":0.1,\"roughnessFactor\":0.7},\"doubleSided\":true"
                   << (m.color[3] < 1.0f ? ",\"alphaMode\":\"BLEND\"" : "") << "}";
     }
@@ -430,8 +440,9 @@ inline bool glb_write_framed_meshopt(const std::string &path, const std::vector<
         meshes << (i ? "," : "") << "{\"name\":\"node" << i
                << "\",\"primitives\":[{\"attributes\":{\"POSITION\":" << i * 2 + 1 << "},\"indices\":" << i * 2
                << ",\"mode\":4,\"material\":" << i << "}]}";
-        materials << (i ? "," : "") << "{\"pbrMetallicRoughness\":{\"baseColorFactor\":[" << fnum(h.color[0]) << ","
-                  << fnum(h.color[1]) << "," << fnum(h.color[2]) << "," << fnum(h.color[3])
+        materials << (i ? "," : "") << "{\"pbrMetallicRoughness\":{\"baseColorFactor\":["
+                  << fnum(srgb_to_linear(h.color[0])) << "," << fnum(srgb_to_linear(h.color[1])) << ","
+                  << fnum(srgb_to_linear(h.color[2])) << "," << fnum(h.color[3])
                   << "],\"metallicFactor\":0.1,\"roughnessFactor\":0.7},\"doubleSided\":true"
                   << (h.color[3] < 1.0f ? ",\"alphaMode\":\"BLEND\"" : "") << "}";
     }

--- a/src/geom/neutral/ngeom_glb.h
+++ b/src/geom/neutral/ngeom_glb.h
@@ -37,6 +37,11 @@ struct FaceSub {
     uint32_t length = 0; // index count (3 * triangles)
     int64_t face_id = 0; // source entity id (STEP/IFC #id), 0 if unknown
     uint32_t seq = 0;    // 0-based face position within the solid
+    // Per-face presentation colour (STEP per-face styling). has_color=false => inherit the solid's base
+    // colour. Used only by split_solid_by_face_colour to bucket a solid's faces into per-colour GlbSolids;
+    // ignored by the picking/draw-range machinery downstream.
+    bool has_color = false;
+    float cr = 0.5f, cg = 0.5f, cb = 0.5f, ca = 1.0f;
 };
 
 struct GlbSolid {
@@ -484,6 +489,74 @@ inline bool glb_write_framed_meshopt(const std::string &path, const std::vector<
 }
 
 } // namespace glb_detail
+
+// Split one tessellated solid into one GlbSolid per DISTINCT face colour, so a per-face-styled solid
+// (STEP AP214 OVER_RIDING_STYLED_ITEM) becomes one glTF primitive/material per colour under the existing
+// merge-by-colour scheme. Each face's effective colour is its own captured colour, else the solid's base
+// colour (`s.color`). Requirements this preserves:
+//   * Solids whose faces all share one colour return a SINGLE GlbSolid (no extra primitives) — identical
+//     to the pre-split output except the base colour is upgraded to that shared face colour when present.
+//   * face_ranges stay valid: each sub-solid's ranges are rebased onto its own compacted index buffer and
+//     still tile it contiguously, so the face_ranges_node<m> picking contract holds per material.
+//   * All geometry is preserved: the split only runs when the captured face ranges cover the whole index
+//     buffer (they do on the capture path); otherwise it degrades to a single primitive (base colour).
+inline std::vector<GlbSolid> split_solid_by_face_colour(const GlbSolid &s) {
+    if (s.face_ranges.empty())
+        return {s}; // no per-face styling captured -> unchanged
+    auto eff = [&](const FaceSub &f) -> std::array<float, 4> {
+        return f.has_color ? std::array<float, 4>{f.cr, f.cg, f.cb, f.ca} : s.color;
+    };
+    std::map<std::array<int, 4>, size_t> group_of; // colour key -> group index (first-appearance order)
+    std::vector<std::array<float, 4>> group_col;
+    size_t covered = 0;
+    for (const FaceSub &f : s.face_ranges) {
+        covered += f.length;
+        auto k = glb_detail::colour_key(eff(f));
+        if (group_of.emplace(k, group_of.size()).second)
+            group_col.push_back(eff(f));
+    }
+    // Single distinct colour (or ranges don't fully tile the buffer -> can't safely re-slice): keep one
+    // primitive, adopting the shared face colour when the faces all override the base.
+    if (group_col.size() <= 1 || covered != s.indices.size()) {
+        GlbSolid one = s;
+        if (group_col.size() == 1)
+            one.color = group_col[0];
+        return {one};
+    }
+    std::vector<GlbSolid> out(group_col.size());
+    const size_t nv = s.positions.size() / 3;
+    std::vector<std::vector<uint32_t>> remap(group_col.size()); // per group: old vertex -> new (compacted)
+    for (size_t g = 0; g < group_col.size(); ++g) {
+        out[g].color = group_col[g];
+        out[g].transforms = s.transforms;
+        out[g].id = s.id;
+        out[g].product_name = s.product_name;
+        out[g].instance_paths = s.instance_paths;
+        remap[g].assign(nv, 0xFFFFFFFFu);
+    }
+    for (const FaceSub &f : s.face_ranges) {
+        size_t g = group_of[glb_detail::colour_key(eff(f))];
+        GlbSolid &o = out[g];
+        std::vector<uint32_t> &rm = remap[g];
+        uint32_t new_start = (uint32_t) o.indices.size();
+        uint32_t end = f.start + f.length;
+        for (uint32_t k = f.start; k < end && k < s.indices.size(); ++k) {
+            uint32_t ov = s.indices[k];
+            uint32_t nvid = (ov < rm.size()) ? rm[ov] : 0xFFFFFFFFu;
+            if (nvid == 0xFFFFFFFFu) {
+                nvid = (uint32_t) (o.positions.size() / 3);
+                if (ov < rm.size())
+                    rm[ov] = nvid;
+                o.positions.push_back(s.positions[3 * ov]);
+                o.positions.push_back(s.positions[3 * ov + 1]);
+                o.positions.push_back(s.positions[3 * ov + 2]);
+            }
+            o.indices.push_back(nvid);
+        }
+        o.face_ranges.push_back({new_start, f.length, f.face_id, f.seq, f.has_color, f.cr, f.cg, f.cb, f.ca});
+    }
+    return out;
+}
 
 // In-RAM merge-by-colour writer (for small/medium inputs + tests). meshopt=true bakes
 // EXT_meshopt_compression directly (falls back to raw on any encode failure).

--- a/src/geom/neutral/ngeom_glb.h
+++ b/src/geom/neutral/ngeom_glb.h
@@ -92,8 +92,10 @@ inline uint32_t pad4(uint32_t n) {
 // the renderer treats the sRGB value as linear and its display gamma-encode lifts mid channels
 // (e.g. deep orange 0.4 -> ~0.67 green), yellowing the colour. Applied to RGB only, not alpha.
 inline float srgb_to_linear(float c) {
-    if (c <= 0.0f) return 0.0f;
-    if (c >= 1.0f) return 1.0f;
+    if (c <= 0.0f)
+        return 0.0f;
+    if (c >= 1.0f)
+        return 1.0f;
     return c <= 0.04045f ? c / 12.92f : std::pow((c + 0.055f) / 1.055f, 2.4f);
 }
 

--- a/src/geom/neutral/ngeom_tess_track.h
+++ b/src/geom/neutral/ngeom_tess_track.h
@@ -198,6 +198,13 @@ struct TessTrackInfo {
     const char *description; // one line, for a tooltip
     bool watertight;         // does it close shared-edge seams?
     bool is_default;         // the track used when no pipeline is given
+    // Does this track mesh NEUTRAL surfaces — the OCC-free path fed by the native STEP/IFC readers
+    // and by the NGEOM wire? The taxonomy tracks do not: they need ifcopenshell taxonomy geometry,
+    // which those readers never build. Handing one to a neutral-surface caller does not fail — it
+    // silently meshes as though no track were selected (occ/cgal/hybrid emit byte-identical output
+    // there, none of it ifcopenshell's). So a caller offering a track CHOICE for a neutral path
+    // must filter on this, or it advertises kernels that path cannot run.
+    bool neutral;
 };
 
 inline std::vector<TessTrackInfo> track_infos() {
@@ -206,22 +213,23 @@ inline std::vector<TessTrackInfo> track_infos() {
          "OCC-free winding-rule tessellation of the trim loop, with a UV-grid fast path for "
          "near-full patches. Boundary vertices are pinned to their shared edge, which halves "
          "shared-edge cracks at no cost.",
-         false, true},
+         false, true, /*neutral=*/true},
         {"cdt", "CDT — watertight (slower)",
          "Constrained Delaunay (detria): trim loops become constraint edges and the surface grid "
          "becomes interior Steiner points. One boundary-first path, so every boundary vertex pins. "
          "Produces watertight, manifold solids with fewer triangles, but costs ~+8% on small models "
          "and can exceed +60% on large multi-solid assemblies.",
-         true, false},
+         true, false, /*neutral=*/true},
     };
 #if !defined(__EMSCRIPTEN__)
     // Taxonomy kernels link OCCT/CGAL via ifcopenshell and are excluded from the wasm build, so they
     // are only real where they are compiled in.
-    out.push_back({"occ", "OCC (ifcopenshell taxonomy)", "Meshes via ifcopenshell's taxonomy on OCCT.", false, false});
-    out.push_back(
-        {"cgal", "CGAL (ifcopenshell taxonomy)", "Meshes via ifcopenshell's taxonomy on CGAL.", false, false});
+    out.push_back({"occ", "OCC (ifcopenshell taxonomy)", "Meshes via ifcopenshell's taxonomy on OCCT.", false, false,
+                   /*neutral=*/false});
+    out.push_back({"cgal", "CGAL (ifcopenshell taxonomy)", "Meshes via ifcopenshell's taxonomy on CGAL.", false, false,
+                   /*neutral=*/false});
     out.push_back({"hybrid", "Hybrid OCC/CGAL (ifcopenshell taxonomy)",
-                   "ifcopenshell's hybrid OCCT/CGAL kernel selection.", false, false});
+                   "ifcopenshell's hybrid OCCT/CGAL kernel selection.", false, false, /*neutral=*/false});
 #endif
     return out;
 }

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -3004,7 +3004,8 @@ static void tessellate_one_root(const NgeomRoot &root, const TessParams &tp, Tes
                 tessellate_face(*face, tp, out);
                 const uint32_t c = (uint32_t) out.indices.size() - s;
                 if (c > 0)
-                    out.face_ranges.push_back({s, c, face->src_id, (uint32_t) fi});
+                    out.face_ranges.push_back({s, c, face->src_id, (uint32_t) fi, face->has_color, face->cr,
+                                               face->cg, face->cb, face->ca});
             } else {
                 tessellate_face(*face, tp, out);
             }

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -128,14 +128,14 @@ const bool DIAG = tess_diag_path() != nullptr;
 
 // Per-face accumulator: one row per face, so a 300k-face model stays a manageable CSV.
 struct FaceDiag {
-    std::vector<double> r;  // residual per boundary point (model units)
-    size_t n_uv_fail = 0;   // surf.uv() returned false
-    size_t n_collapsed = 0; // ...and the handler collapsed point i onto i-1 (Defect 2 fired)
-    const char *path = "?";     // which branch of face_to_mesh took the face
-    double emitted_area = 0;    // 3D area actually tessellated for this face
-    double expected_area = 0;   // expected trimmed surface area (region-fill faces only)
-    bool has_coverage = false;  // expected_area is meaningful (not a winding/periodic face)
-    size_t n_tris = 0;          // triangles emitted for this face (characterization)
+    std::vector<double> r;     // residual per boundary point (model units)
+    size_t n_uv_fail = 0;      // surf.uv() returned false
+    size_t n_collapsed = 0;    // ...and the handler collapsed point i onto i-1 (Defect 2 fired)
+    const char *path = "?";    // which branch of face_to_mesh took the face
+    double emitted_area = 0;   // 3D area actually tessellated for this face
+    double expected_area = 0;  // expected trimmed surface area (region-fill faces only)
+    bool has_coverage = false; // expected_area is meaningful (not a winding/periodic face)
+    size_t n_tris = 0;         // triangles emitted for this face (characterization)
 };
 
 // thread_local: DIAG forces threads=1 (see tessellate_one_root), but a stray parallel caller must
@@ -193,8 +193,8 @@ void diag_flush_face(const Surface &surf, int64_t face_id, uint32_t face_seq, do
     double coverage = (d.has_coverage && d.expected_area > 1e-12) ? d.emitted_area / d.expected_area : -1.0;
     std::fprintf(t.fh, "%u,%lld,%s,%d,%s,%zu,%zu,%zu,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.6g,%.6g,%.4g,%zu\n",
                  face_seq, (long long) face_id, surf_kind(surf), (int) surf.is_quadric(), d.path, d.r.size(),
-                 d.n_uv_fail, d.n_collapsed, p50, p95, mx, p50 / sz, p95 / sz, mx / sz, sz, model_scale,
-                 d.emitted_area, d.has_coverage ? d.expected_area : -1.0, coverage, d.n_tris);
+                 d.n_uv_fail, d.n_collapsed, p50, p95, mx, p50 / sz, p95 / sz, mx / sz, sz, model_scale, d.emitted_area,
+                 d.has_coverage ? d.expected_area : -1.0, coverage, d.n_tris);
     d = FaceDiag{};
 }
 
@@ -2382,8 +2382,8 @@ const char *face_to_mesh(const Surface &surf, const std::vector<Loop3> &loops3d,
     // attachment — came out as the small hose-side cap with the gasket itself missing. Route those to
     // the complement tessellation. Measured on KR_6: exactly 2 faces flip (the gaskets); every other
     // quadric face (1925 of them) is interior-material and unchanged.
-    if (auto per_u = surf.u_period(); per_u && loops_uv.size() == 1 && loops_uv[0].w == 0
-                                      && loops_uv[0].uv.size() >= 3) {
+    if (auto per_u = surf.u_period();
+        per_u && loops_uv.size() == 1 && loops_uv[0].w == 0 && loops_uv[0].uv.size() >= 3) {
         const auto &L = loops_uv[0].uv;
         double area = 0, uc = 0, vc = 0;
         for (size_t i = 0; i < L.size(); ++i) {
@@ -3249,8 +3249,8 @@ static void tessellate_one_root(const NgeomRoot &root, const TessParams &tp, Tes
                 tessellate_face(*face, tp, out);
                 const uint32_t c = (uint32_t) out.indices.size() - s;
                 if (c > 0)
-                    out.face_ranges.push_back({s, c, face->src_id, (uint32_t) fi, face->has_color, face->cr,
-                                               face->cg, face->cb, face->ca});
+                    out.face_ranges.push_back(
+                        {s, c, face->src_id, (uint32_t) fi, face->has_color, face->cr, face->cg, face->cb, face->ca});
             } else {
                 tessellate_face(*face, tp, out);
             }

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -43,6 +43,18 @@ const bool FDBG = std::getenv("NGEOM_FDBG") != nullptr;
 // triangle counts, all tess params) — for head-to-head comparison with the reference tessellator's face-debug dump.
 const bool TESSDBG = std::getenv("NGEOM_TESSDBG") != nullptr;
 
+// ADA_BAND_DEBUG: per-band arc-length loft diagnostics (periodic tube bands). Prints, for each band,
+// the two rings' sizes and the max cross-ring arc-length skew of BOTH the new aligned loft AND the
+// legacy libtess2 monotone triangulation (run side by side), so the de-twist is measurable from one
+// binary. A small loft skew (~one segment) vs a large legacy skew (drift toward ~0.5) IS the twist.
+const bool BANDDBG = std::getenv("ADA_BAND_DEBUG") != nullptr;
+// ADA_BAND_LEGACY: force the pre-fix polygon+libtess2 band path (the twisting one). Escape hatch and
+// A/B lever; the arc-length loft is the default.
+const bool BAND_LEGACY = std::getenv("ADA_BAND_LEGACY") != nullptr;
+// Source entity id of the face currently being tessellated, for targeted band debug. Thread-local so
+// the parallel face pool cannot interleave; set once per face in tessellate_face.
+thread_local int64_t g_cur_face_id = 0;
+
 // Face-merge batch size for the huge single-root face-parallel path (tessellate_one_root). The
 // per-face local meshes are held resident until merged; on a 61k-face monster solid the full
 // locals[] is a SECOND complete copy of the solid's soup (~0.5 GB with normals), inflating that
@@ -1710,6 +1722,181 @@ bool tessellate_periodic_winding(const Surface &s, const std::vector<LoopUv> &lo
     return emit_uv_region(s, all, tp, same_sense, mesh);
 }
 
+// Normalized cumulative 3D arc length along a ring of UV points (chord length between consecutive
+// surface points / total). This is the correspondence parameter for the loft: two rings evaluated at
+// the same fraction sit at the same angular position around the tube, so linking them makes a
+// "vertical" quad strip rather than a diagonal spiral. Falls back to index-fraction for a null-length
+// ring so the merge below still terminates.
+std::vector<double> ring_arc_norm(const Surface &s, const std::vector<Uv> &r) {
+    std::vector<double> c(r.size(), 0.0);
+    if (r.size() < 2)
+        return c;
+    Vec3 prev = s.point(r[0][0], r[0][1]);
+    for (size_t k = 1; k < r.size(); ++k) {
+        Vec3 cur = s.point(r[k][0], r[k][1]);
+        c[k] = c[k - 1] + (cur - prev).norm();
+        prev = cur;
+    }
+    double tot = c.back();
+    if (tot > 1e-300)
+        for (double &x : c)
+            x /= tot;
+    else
+        for (size_t k = 0; k < c.size(); ++k)
+            c[k] = (double) k / (double) (c.size() - 1);
+    return c;
+}
+
+// Two-pointer arc-length strip merge of the two boundary rings (bottom, top) of a periodic band.
+// Returns the aligned quad triangulation (2 tris/quad) over a COMBINED vertex list [bottom | top]:
+// bottom vertex i is index i, top vertex j is index bottom.size()+j. Every triangle uses ONLY
+// original ring vertices — no interior/Steiner point is created — so no shared boundary vertex moves
+// and the band stays watertight to its neighbours; the closed-U seam closes exactly as before because
+// the ring endpoints (u=c and u=c+period) evaluate to the same surface point and the per-solid weld
+// fuses them. Because we always advance whichever ring is BEHIND in normalized arc length, the two
+// linked vertices never differ by more than one segment in arc length: the strip cannot drift/spiral,
+// which is the whole point (libtess2's monotone triangulation of bottom+reversed-top drifts).
+std::vector<Tri> band_loft_strip(const std::vector<double> &sb, const std::vector<double> &st, size_t nb, size_t nt) {
+    std::vector<Tri> tris;
+    if (nb < 2 || nt < 2)
+        return tris;
+    tris.reserve(nb + nt);
+    auto BI = [](size_t i) { return (uint32_t) i; };
+    auto TI = [&](size_t j) { return (uint32_t) (nb + j); };
+    size_t i = 0, j = 0;
+    while (i + 1 < nb || j + 1 < nt) {
+        bool adv_bottom;
+        if (i + 1 >= nb)
+            adv_bottom = false;
+        else if (j + 1 >= nt)
+            adv_bottom = true;
+        else
+            adv_bottom = sb[i + 1] <= st[j + 1];
+        if (adv_bottom) {
+            tris.push_back({BI(i), BI(i + 1), TI(j)});
+            ++i;
+        } else {
+            tris.push_back({BI(i), TI(j), TI(j + 1)});
+            ++j;
+        }
+    }
+    return tris;
+}
+
+// Max cross-ring arc-length skew of a strip: over every triangle edge that links a bottom vertex to a
+// top vertex, the largest |arc_bottom - arc_top|. Aligned quads keep this ~one segment; a drifting
+// (twisted) triangulation lets it grow toward ~0.5. Used only for ADA_BAND_DEBUG evidence.
+double strip_arc_skew(const std::vector<Tri> &tris, const std::vector<double> &sb, const std::vector<double> &st,
+                      size_t nb) {
+    double mx = 0.0;
+    for (const Tri &t : tris)
+        for (int k = 0; k < 3; ++k) {
+            uint32_t a = t[k], b = t[(k + 1) % 3];
+            bool a_bot = a < nb, b_bot = b < nb;
+            if (a_bot == b_bot)
+                continue; // same ring: not a connecting edge
+            double arc_b = a_bot ? sb[a] : sb[b];
+            double arc_t = a_bot ? st[b - nb] : st[a - nb];
+            mx = std::max(mx, std::abs(arc_b - arc_t));
+        }
+    return mx;
+}
+
+// Structured arc-length loft of a band's two boundary rings into aligned quads, then the SAME
+// refine/emit tail as emit_uv_region (refine_uv adds curvature subdivision in u and v for a bending
+// tube; no pins, so the boundary is handled exactly as the prior band path did). This REPLACES
+// libtess2's monotone CDT of (bottom + reversed-top), which linked bottom[i] to a drifting top[k] and
+// so spiralled the tube.
+bool emit_band_loft(const Surface &s, const std::vector<Uv> &bottom, const std::vector<Uv> &top, const TessParams &tp,
+                    bool same_sense, Mesh &mesh) {
+    const size_t nb = bottom.size(), nt = top.size();
+    if (nb < 2 || nt < 2)
+        return false;
+    std::vector<double> sb = ring_arc_norm(s, bottom);
+    std::vector<double> st = ring_arc_norm(s, top);
+    std::vector<Tri> tris = band_loft_strip(sb, st, nb, nt);
+    if (tris.empty())
+        return false;
+
+    std::vector<Uv> verts;
+    verts.reserve(nb + nt);
+    for (const Uv &p : bottom)
+        verts.push_back(p);
+    for (const Uv &p : top)
+        verts.push_back(p);
+
+    if (BANDDBG) {
+        // Side-by-side: the legacy libtess2 triangulation of the same rings, scored on the same skew
+        // metric, so the twist is visible from one run. run_tess2 emits no interior points, so every
+        // legacy output vertex is an original ring vertex — recoverable by nearest-ring-vertex match.
+        double umn = INF, umx = -INF, vmn = INF, vmx = -INF;
+        for (const Uv &p : verts) {
+            umn = std::min(umn, p[0]);
+            umx = std::max(umx, p[0]);
+            vmn = std::min(vmn, p[1]);
+            vmx = std::max(vmx, p[1]);
+        }
+        auto [su2, sv2] = metric_scale(s, umn, umx, vmn, vmx);
+        std::vector<Uv> poly = bottom;
+        for (auto it = top.rbegin(); it != top.rend(); ++it)
+            poly.push_back(*it);
+        Tess2Out lg = run_tess2({poly}, su2, sv2);
+        double legacy_skew = -1.0;
+        if (lg.ok) {
+            // map each legacy vertex to (ring, arc) by nearest original ring vertex in UV
+            std::vector<uint32_t> ring_idx(lg.verts.size());
+            std::vector<char> ring_is_bot(lg.verts.size());
+            for (size_t vk = 0; vk < lg.verts.size(); ++vk) {
+                double best = INF;
+                uint32_t bi = 0;
+                char bot = 1;
+                for (size_t q = 0; q < verts.size(); ++q) {
+                    double d = std::abs(verts[q][0] - lg.verts[vk][0]) + std::abs(verts[q][1] - lg.verts[vk][1]);
+                    if (d < best) {
+                        best = d;
+                        bot = q < nb ? 1 : 0;
+                        bi = bot ? (uint32_t) q : (uint32_t) (q - nb);
+                    }
+                }
+                ring_idx[vk] = bi;
+                ring_is_bot[vk] = bot;
+            }
+            legacy_skew = 0.0;
+            for (const Tri &t : lg.tris)
+                for (int k = 0; k < 3; ++k) {
+                    uint32_t a = t[k], b = t[(k + 1) % 3];
+                    if (ring_is_bot[a] == ring_is_bot[b])
+                        continue;
+                    double arc_b = ring_is_bot[a] ? sb[ring_idx[a]] : sb[ring_idx[b]];
+                    double arc_t = ring_is_bot[a] ? st[ring_idx[b]] : st[ring_idx[a]];
+                    legacy_skew = std::max(legacy_skew, std::abs(arc_b - arc_t));
+                }
+        }
+        double seg = 0.0;
+        for (size_t k = 1; k < nb; ++k)
+            seg = std::max(seg, sb[k] - sb[k - 1]);
+        for (size_t k = 1; k < nt; ++k)
+            seg = std::max(seg, st[k] - st[k - 1]);
+        std::fprintf(stderr,
+                     "[BANDDBG] face=%lld bottom=%zu top=%zu tris=%zu loft_arc_skew=%.4f "
+                     "legacy_arc_skew=%.4f max_seg=%.4f%s\n",
+                     (long long) g_cur_face_id, nb, nt, tris.size(), strip_arc_skew(tris, sb, st, nb), legacy_skew, seg,
+                     strip_arc_skew(tris, sb, st, nb) <= seg + 1e-9 ? " ALIGNED" : " DRIFT");
+    }
+
+    double umin = INF, umax = -INF, vmin = INF, vmax = -INF;
+    for (const Uv &p : verts) {
+        umin = std::min(umin, p[0]);
+        umax = std::max(umax, p[0]);
+        vmin = std::min(vmin, p[1]);
+        vmax = std::max(vmax, p[1]);
+    }
+    auto [su, sv] = metric_scale(s, umin, umax, vmin, vmax);
+    refine_and_emit(s, std::move(verts), std::move(tris), su, sv, tp, same_sense, mesh, {}, tp.libtess2.freeze_boundary,
+                    tp.libtess2.converged_frac);
+    return true;
+}
+
 bool tessellate_periodic_band(const Surface &s, const std::vector<LoopUv> &loops_uv, const TessParams &tp,
                               bool same_sense, Mesh &mesh) {
     auto puopt = s.u_period();
@@ -1822,10 +2009,9 @@ bool tessellate_periodic_band(const Surface &s, const std::vector<LoopUv> &loops
         const BandCurve &bottom = curves[i];
         const BandCurve &top = curves[i + 1];
         double vb = mean_v(bottom), vt = mean_v(top);
-        std::vector<Uv> poly = bottom.pts;
-        for (auto it = top.pts.rbegin(); it != top.pts.rend(); ++it)
-            poly.push_back(*it);
-        std::vector<std::vector<Uv>> contours = {poly};
+        // Holes that fall inside this band's v-span: a simple ring-to-ring loft cannot carve a hole,
+        // so a holed band keeps the libtess2 CDT path below (correctness over de-twist for that case).
+        std::vector<std::vector<Uv>> band_holes;
         for (const auto &h : holes) {
             double hv = 0;
             for (const Uv &p : h)
@@ -1842,9 +2028,25 @@ bool tessellate_periodic_band(const Surface &s, const std::vector<LoopUv> &loops
                 if (shift != 0.0)
                     for (Uv &p : hh)
                         p[0] -= shift;
-                contours.push_back(hh);
+                band_holes.push_back(std::move(hh));
             }
         }
+        // Default: structured arc-length loft (aligned quads, cannot twist). Fall back to libtess2's
+        // monotone triangulation only when the band has a hole (loft can't represent it) or a ring is
+        // degenerate, or when ADA_BAND_LEGACY forces the pre-fix path.
+        if (!BAND_LEGACY && band_holes.empty() && bottom.pts.size() >= 2 && top.pts.size() >= 2) {
+            any |= emit_band_loft(s, bottom.pts, top.pts, tp, same_sense, mesh);
+            continue;
+        }
+        if (BANDDBG)
+            std::fprintf(stderr, "[BANDDBG] face=%lld FALLBACK-LEGACY bottom=%zu top=%zu band_holes=%zu\n",
+                         (long long) g_cur_face_id, bottom.pts.size(), top.pts.size(), band_holes.size());
+        std::vector<Uv> poly = bottom.pts;
+        for (auto it = top.pts.rbegin(); it != top.pts.rend(); ++it)
+            poly.push_back(*it);
+        std::vector<std::vector<Uv>> contours = {poly};
+        for (auto &hh : band_holes)
+            contours.push_back(std::move(hh));
         any |= emit_uv_region(s, contours, tp, same_sense, mesh);
     }
     return any;
@@ -2539,6 +2741,7 @@ void reset_tess_face_stats() {
 
 bool tessellate_face(const FaceSurfaceN &face, const TessParams &tp, TessMesh &outm) {
     const size_t i0 = outm.indices.size();
+    g_cur_face_id = face.src_id; // for targeted band debug (ADA_BAND_DEBUG)
     bool ok;
     if (!FDBG && !TESSDBG) {
         ok = tessellate_face_impl(face, tp, outm);

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -2154,11 +2154,18 @@ const char *face_to_mesh(const Surface &surf, const std::vector<Loop3> &loops3d,
                 vmn = std::min(vmn, q[1]);
                 vmx = std::max(vmx, q[1]);
             }
-        // dv > ~one full period means the boundary wrapped the minor circle and the v-unwrap drifted
-        // (a valid single-valued torus face spans at most one period; a full-circle cross-section
-        // reaches ~per_v plus one discretization step of closing overlap, so 1.1x is the safe line —
-        // it catches the drifters, which start ~1.12 periods, and leaves genuine full circles alone).
-        if (vmx - vmn > 1.1 * *per_v && umx - umn < *per_v) {
+        // dv > one full period means the boundary wrapped the minor circle and the v-unwrap drifted:
+        // a full v-wrap MUST span >= per_v (you can't traverse the whole minor circle in less), while a
+        // non-wrapping single-valued face spans < per_v. So per_v is the exact separatrix. The overshoot
+        // beyond per_v is drift from the face's u-caps and SHRINKS as the sampling coarsens — measured
+        // on KR_6 face #42987: 1.216x per_v at 128 boundary pts (fine) but only 1.084x at 83 pts under
+        // adaptive coarsening. The old 1.1x line was calibrated on fine tessellation (drifters seen
+        // >=1.12x) and wrongly dropped the coarsened 1.084x drifter into the periodic-complement branch
+        // -> the whole torus tessellated (rogue-donut artifact). Non-winding torus faces top out at
+        // 0.99x per_v on this model, so 1.02x clears them with margin while catching coarsened drifters.
+        // Catching a genuine full ring here is harmless: the grid below tessellates [vmn, vmn+per_v],
+        // which IS the full ring.
+        if (vmx - vmn > 1.02 * *per_v && umx - umn < *per_v) {
             diag_set_path("v_wind_band");
             return tessellate_uv_grid(surf, umn, umx, vmn, vmn + *per_v, tp, same_sense, mesh)
                        ? nullptr

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -119,7 +119,10 @@ struct FaceDiag {
     std::vector<double> r;  // residual per boundary point (model units)
     size_t n_uv_fail = 0;   // surf.uv() returned false
     size_t n_collapsed = 0; // ...and the handler collapsed point i onto i-1 (Defect 2 fired)
-    const char *path = "?"; // which branch of face_to_mesh took the face
+    const char *path = "?";     // which branch of face_to_mesh took the face
+    double emitted_area = 0;    // 3D area actually tessellated for this face
+    double expected_area = 0;   // expected trimmed surface area (region-fill faces only)
+    bool has_coverage = false;  // expected_area is meaningful (not a winding/periodic face)
 };
 
 // thread_local: DIAG forces threads=1 (see tessellate_one_root), but a stray parallel caller must
@@ -132,6 +135,21 @@ FaceDiag &face_diag() {
 void diag_set_path(const char *p) {
     if (DIAG)
         face_diag().path = p;
+}
+
+// Per-face coverage health (always on, independent of DIAG): the expected trimmed surface area of a
+// region-fill face, set by face_to_mesh from the UV loops, read back by tessellate_face to compare
+// against the area actually emitted. Catches PARTIAL tessellation (a self-intersecting UV loop that
+// tess2 fills only halfway -> a hole the zero-triangle drop counter never sees), which is the gap
+// the drop counter alone leaves open. has_expected is false for winding/periodic faces, whose UV-loop
+// area is not the face area, so they never false-flag.
+struct FaceHealth {
+    double expected_area = 0;
+    bool has_expected = false;
+};
+FaceHealth &face_health() {
+    static thread_local FaceHealth h;
+    return h;
 }
 
 double pct(std::vector<double> &v, double q) {
@@ -153,14 +171,17 @@ void diag_flush_face(const Surface &surf, int64_t face_id, uint32_t face_seq, do
         if (!t.fh)
             return;
         std::fprintf(t.fh, "face_seq,face_id,surf_kind,is_quadric,path_taken,n_bpts,n_uv_fail,n_collapsed,"
-                           "r_p50,r_p95,r_max,r_rel_p50,r_rel_p95,r_rel_max,approx_size,model_scale\n");
+                           "r_p50,r_p95,r_max,r_rel_p50,r_rel_p95,r_rel_max,approx_size,model_scale,"
+                           "emitted_area,expected_area,coverage\n");
     }
     double sz = std::max(surf.approx_size(), 1.0);
     double p50 = pct(d.r, 0.50), p95 = pct(d.r, 0.95);
     double mx = d.r.empty() ? 0.0 : *std::max_element(d.r.begin(), d.r.end());
-    std::fprintf(t.fh, "%u,%lld,%s,%d,%s,%zu,%zu,%zu,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g\n", face_seq,
-                 (long long) face_id, surf_kind(surf), (int) surf.is_quadric(), d.path, d.r.size(), d.n_uv_fail,
-                 d.n_collapsed, p50, p95, mx, p50 / sz, p95 / sz, mx / sz, sz, model_scale);
+    double coverage = (d.has_coverage && d.expected_area > 1e-12) ? d.emitted_area / d.expected_area : -1.0;
+    std::fprintf(t.fh, "%u,%lld,%s,%d,%s,%zu,%zu,%zu,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.6g,%.6g,%.4g\n",
+                 face_seq, (long long) face_id, surf_kind(surf), (int) surf.is_quadric(), d.path, d.r.size(),
+                 d.n_uv_fail, d.n_collapsed, p50, p95, mx, p50 / sz, p95 / sz, mx / sz, sz, model_scale,
+                 d.emitted_area, d.has_coverage ? d.expected_area : -1.0, coverage);
     d = FaceDiag{};
 }
 
@@ -2087,6 +2108,48 @@ const char *face_to_mesh(const Surface &surf, const std::vector<Loop3> &loops3d,
         loops_uv.push_back({std::move(uv), std::move(pts3), w, interior_above});
     }
 
+    // Coverage health: expected trimmed surface area = |net signed UV-loop area| * surface Jacobian at
+    // the UV centre. Exact for constant-Jacobian surfaces (plane/cylinder/cone), a good estimate for
+    // B-splines. Skipped when any loop winds (w != 0) or a period is present: there the UV-loop area is
+    // not the face area (the face wraps a seam), so a ratio against emitted would be meaningless.
+    {
+        FaceHealth &h = face_health();
+        h = FaceHealth{};
+        double umn = INF, umx = -INF, vmn = INF, vmx = -INF, net_uv = 0;
+        bool wraps = false;
+        for (const LoopUv &L : loops_uv) {
+            if (L.w != 0)
+                wraps = true; // u-winding loop: the face spans the seam, UV area != face area
+            double a = 0;
+            for (size_t i = 0; i < L.uv.size(); ++i) {
+                const Uv &p = L.uv[i], &q = L.uv[(i + 1) % L.uv.size()];
+                a += p[0] * q[1] - q[0] * p[1];
+                umn = std::min(umn, p[0]);
+                umx = std::max(umx, p[0]);
+                vmn = std::min(vmn, p[1]);
+                vmx = std::max(vmx, p[1]);
+            }
+            net_uv += 0.5 * a; // holes wind opposite the outer loop, so they subtract
+        }
+        // A period EXISTING doesn't disqualify a face (a 30-deg cylinder patch has u_period=2pi but a
+        // small u-span); only a face whose UV region actually covers a full period wraps the seam, so
+        // its UV-loop area is not the trimmed area. Those (and winding loops) are excluded; ordinary
+        // quadric patches (the dropped-cylinder class) stay IN the coverage check.
+        if (auto pu = surf.u_period(); pu && (umx - umn) > 0.99 * *pu)
+            wraps = true;
+        if (auto pv = surf.v_period(); pv && (vmx - vmn) > 0.99 * *pv)
+            wraps = true;
+        if (!wraps && !loops_uv.empty()) {
+            double uc = 0.5 * (umn + umx), vc = 0.5 * (vmn + vmx);
+            double hu = std::max((umx - umn) * 1e-4, 1e-9), hv = std::max((vmx - vmn) * 1e-4, 1e-9);
+            Vec3 ru = surf.point(uc + hu, vc) - surf.point(uc - hu, vc);
+            Vec3 rv = surf.point(uc, vc + hv) - surf.point(uc, vc - hv);
+            double jac = ru.cross(rv).norm() / (4.0 * hu * hv); // |dP/du x dP/dv|
+            h.expected_area = std::abs(net_uv) * jac;
+            h.has_expected = std::isfinite(h.expected_area);
+        }
+    }
+
     // ISO 10303-42 material-side selection for a single non-winding loop on a periodic surface. STEP
     // defines the face's material via same_sense + FACE_OUTER_BOUND.orientation relative to the
     // surface normal; the loop is INTERIOR-material iff sign(signed UV area) * sign(du x dv . normal)
@@ -2414,15 +2477,23 @@ bool tessellate_face_impl(const FaceSurfaceN &face, const TessParams &tp, TessMe
 // increment safely; reset once single-threaded before a conversion, read after the pools join.
 static std::atomic<std::uint64_t> g_dropped_faces{0};
 static std::atomic<std::uint64_t> g_total_faces{0};
+// Faces that tessellated but covered < half their expected surface area — a partial fill (e.g. a
+// self-intersecting UV loop tess2 only half-filled). Distinct from dropped (zero triangles); this is
+// the "detection gap" the drop counter alone leaves: geometry that is present but incomplete.
+static std::atomic<std::uint64_t> g_suspect_faces{0};
 std::uint64_t tess_dropped_faces() {
     return g_dropped_faces.load(std::memory_order_relaxed);
 }
 std::uint64_t tess_total_faces() {
     return g_total_faces.load(std::memory_order_relaxed);
 }
+std::uint64_t tess_suspect_faces() {
+    return g_suspect_faces.load(std::memory_order_relaxed);
+}
 void reset_tess_face_stats() {
     g_dropped_faces.store(0, std::memory_order_relaxed);
     g_total_faces.store(0, std::memory_order_relaxed);
+    g_suspect_faces.store(0, std::memory_order_relaxed);
 }
 
 bool tessellate_face(const FaceSurfaceN &face, const TessParams &tp, TessMesh &outm) {
@@ -2449,10 +2520,30 @@ bool tessellate_face(const FaceSurfaceN &face, const TessParams &tp, TessMesh &o
         if (TESSDBG)
             std::fprintf(stderr, "TESSDBG FACE-DONE tris=%zu ok=%d\n", (outm.indices.size() - i0) / 3, (int) ok);
     }
-    // Health accounting (always on): a face carrying a real trim boundary that yields NO triangles is
-    // UV-inversion residual row for this face (ADA_TESS_DIAG only; no-op otherwise). Emitted after
-    // the impl so `path` names the branch actually taken, including any retry tier.
+    // Coverage health (always on): sum the 3D area this face actually emitted and compare it to the
+    // expected trimmed area face_to_mesh computed from the UV loops. A partial fill (< half the
+    // expected area) is a face that tessellated but left a hole — the gap the zero-triangle drop
+    // counter can't see. FaceHealth is consumed (and reset) here regardless of DIAG.
+    FaceHealth &fh = face_health();
+    double emitted_area = 0;
+    {
+        const auto &pos = outm.positions;
+        const auto &idx = outm.indices;
+        for (size_t k = i0; k + 2 < idx.size(); k += 3) {
+            uint32_t a = idx[k], b = idx[k + 1], c = idx[k + 2];
+            if (3 * (size_t) c + 2 >= pos.size())
+                continue;
+            Vec3 A{pos[3 * a], pos[3 * a + 1], pos[3 * a + 2]};
+            Vec3 B{pos[3 * b], pos[3 * b + 1], pos[3 * b + 2]};
+            Vec3 C{pos[3 * c], pos[3 * c + 1], pos[3 * c + 2]};
+            emitted_area += 0.5 * (B - A).cross(C - A).norm();
+        }
+    }
     if (DIAG && face.surface) {
+        FaceDiag &d = face_diag();
+        d.emitted_area = emitted_area;
+        d.expected_area = fh.expected_area;
+        d.has_coverage = fh.has_expected;
         static std::atomic<uint32_t> g_diag_seq{0};
         diag_flush_face(*face.surface, face.src_id, g_diag_seq.fetch_add(1, std::memory_order_relaxed),
                         tls_model_scale());
@@ -2460,8 +2551,13 @@ bool tessellate_face(const FaceSurfaceN &face, const TessParams &tp, TessMesh &o
     // silently dropped geometry — count it. Uses the emitted-triangle delta, not `ok`, since some
     // failures still return true with an empty result.
     g_total_faces.fetch_add(1, std::memory_order_relaxed);
-    if (outm.indices.size() == i0 && !face.bounds.empty())
+    bool dropped = outm.indices.size() == i0 && !face.bounds.empty();
+    if (dropped)
         g_dropped_faces.fetch_add(1, std::memory_order_relaxed);
+    // Partial fill: tessellated (not dropped) but covered < half the expected area — the detection gap.
+    else if (fh.has_expected && fh.expected_area > 1e-6 && emitted_area < 0.5 * fh.expected_area)
+        g_suspect_faces.fetch_add(1, std::memory_order_relaxed);
+    fh = FaceHealth{}; // reset for the next face (DIAG-independent)
     return ok;
 }
 

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -2075,6 +2075,30 @@ const char *face_to_mesh(const Surface &surf, const std::vector<Loop3> &loops3d,
     for (const LoopUv &l : loops_uv)
         if (!uv_slit(l))
             all_slit = false;
+    // V-winding band: a doubly-periodic surface (torus/tube) whose boundary sweeps a full minor
+    // circle in v while spanning only a short arc in u. The per-point unwrap keeps consecutive v
+    // within half a period, so a full wrap DOESN'T fold back — v drifts monotonically past per_v and
+    // the UV loop collapses to a near-degenerate vertical sliver. That sliver has ~zero polygon area,
+    // so it's misclassified as a slit and tessellated as the WHOLE torus (measured: 118 such faces
+    // produced 57x their true surface area on KR_6). The u-winding case is already handled above;
+    // this is its v analog. Tessellate the real geometry directly: a grid band over the actual small
+    // u-arc x one full minor period.
+    if (per_v && !loops_uv.empty()) {
+        double umn = INF, umx = -INF, vmn = INF, vmx = -INF;
+        for (const auto &lp : loops_uv)
+            for (const Uv &q : lp.uv) {
+                umn = std::min(umn, q[0]);
+                umx = std::max(umx, q[0]);
+                vmn = std::min(vmn, q[1]);
+                vmx = std::max(vmx, q[1]);
+            }
+        if (vmx - vmn > 1.5 * *per_v && umx - umn < *per_v) {
+            diag_set_path("v_wind_band");
+            return tessellate_uv_grid(surf, umn, umx, vmn, vmn + *per_v, tp, same_sense, mesh)
+                       ? nullptr
+                       : "v-winding band tessellation failed";
+        }
+    }
     if (all_slit) {
         diag_set_path("unbounded_slit");
         return tessellate_unbounded(surf, tp, same_sense, mesh) ? nullptr : "slit/full-surface tessellation failed";

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -2092,7 +2092,11 @@ const char *face_to_mesh(const Surface &surf, const std::vector<Loop3> &loops3d,
                 vmn = std::min(vmn, q[1]);
                 vmx = std::max(vmx, q[1]);
             }
-        if (vmx - vmn > 1.5 * *per_v && umx - umn < *per_v) {
+        // dv > ~one full period means the boundary wrapped the minor circle and the v-unwrap drifted
+        // (a valid single-valued torus face spans at most one period; a full-circle cross-section
+        // reaches ~per_v plus one discretization step of closing overlap, so 1.1x is the safe line —
+        // it catches the drifters, which start ~1.12 periods, and leaves genuine full circles alone).
+        if (vmx - vmn > 1.1 * *per_v && umx - umn < *per_v) {
             diag_set_path("v_wind_band");
             return tessellate_uv_grid(surf, umn, umx, vmn, vmn + *per_v, tp, same_sense, mesh)
                        ? nullptr

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -2059,6 +2059,40 @@ const char *face_to_mesh(const Surface &surf, const std::vector<Loop3> &loops3d,
         loops_uv.push_back({std::move(uv), std::move(pts3), w, interior_above});
     }
 
+    // ISO 10303-42 material-side selection for a single non-winding loop on a periodic surface. STEP
+    // defines the face's material via same_sense + FACE_OUTER_BOUND.orientation relative to the
+    // surface normal; the loop is INTERIOR-material iff sign(signed UV area) * sign(du x dv . normal)
+    // * same_sense > 0, else the COMPLEMENT. run_tess2's TESS_WINDING_ODD always fills the interior,
+    // so a complement-material face — e.g. a spherical gasket whose boundary encircles the hose
+    // attachment — came out as the small hose-side cap with the gasket itself missing. Route those to
+    // the complement tessellation. Measured on KR_6: exactly 2 faces flip (the gaskets); every other
+    // quadric face (1925 of them) is interior-material and unchanged.
+    if (auto per_u = surf.u_period(); per_u && loops_uv.size() == 1 && loops_uv[0].w == 0
+                                      && loops_uv[0].uv.size() >= 3) {
+        const auto &L = loops_uv[0].uv;
+        double area = 0, uc = 0, vc = 0;
+        for (size_t i = 0; i < L.size(); ++i) {
+            const Uv &a = L[i], &b = L[(i + 1) % L.size()];
+            area += a[0] * b[1] - b[0] * a[1];
+            uc += a[0];
+            vc += a[1];
+        }
+        uc /= (double) L.size();
+        vc /= (double) L.size();
+        const double h = 1e-4;
+        double jdot = (surf.point(uc + h, vc) - surf.point(uc - h, vc))
+                          .cross(surf.point(uc, vc + h) - surf.point(uc, vc - h))
+                          .dot(surf.normal(uc, vc));
+        const int A = area > 0 ? 1 : -1, J = jdot > 0 ? 1 : -1, S = same_sense ? 1 : -1;
+        if (A * J * S < 0) {
+            diag_set_path("iso_complement");
+            std::vector<std::vector<Uv>> contour = {L};
+            return tessellate_periodic_complement(surf, contour, *per_u, tp, same_sense, mesh)
+                       ? nullptr
+                       : "iso-complement tessellation failed";
+        }
+    }
+
     auto uv_slit = [&](const LoopUv &l) {
         if (l.w != 0)
             return false;

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -381,9 +381,37 @@ struct Tess2Out {
 // emitted on the shared edge. When present, out.pin is filled via libtess2's vertex-index map —
 // original boundary vertices carry their pin; Steiner/new vertices get NaN. Null (the default track)
 // => not one extra byte or branch in the hot loop.
-Tess2Out run_tess2(const std::vector<std::vector<Uv>> &loops_uv, double su, double sv,
+Tess2Out run_tess2(const std::vector<std::vector<Uv>> &loops_uv_in, double su, double sv,
                    const std::vector<std::vector<Vec3>> *loops_p3 = nullptr) {
     Tess2Out out;
+    // Re-center the UV loops to their min corner before handing them to libtess2. TESSreal is float,
+    // so a face whose parametric coordinates carry a large offset — e.g. a cylinder whose STEP axis
+    // placement sits kilometres from the face, giving an axial v ~6e6 — loses its sub-mm real extent
+    // to float precision: every vertex snaps to the same value, the loop collapses to a line, tess2
+    // returns no triangles and the face silently drops (violating "no geom left behind"). Translating
+    // to the origin keeps the true extent representable; the offset is added back to the output verts,
+    // so the transform is invisible to callers and composes with any su/sv scaling. (measured: cylinder
+    // faces #39996/#40030 on KR_6, v~6e6, dropped -> recovered.)
+    double u0 = INF, v0 = INF;
+    for (const auto &lp : loops_uv_in)
+        for (const Uv &p : lp) {
+            u0 = std::min(u0, p[0]);
+            v0 = std::min(v0, p[1]);
+        }
+    if (!std::isfinite(u0))
+        u0 = 0.0;
+    if (!std::isfinite(v0))
+        v0 = 0.0;
+    std::vector<std::vector<Uv>> shifted;
+    shifted.reserve(loops_uv_in.size());
+    for (const auto &lp : loops_uv_in) {
+        std::vector<Uv> s;
+        s.reserve(lp.size());
+        for (const Uv &p : lp)
+            s.push_back({p[0] - u0, p[1] - v0});
+        shifted.push_back(std::move(s));
+    }
+    const std::vector<std::vector<Uv>> &loops_uv = shifted;
     TESStesselator *t = tessNewTess(nullptr);
     if (!t)
         return out;
@@ -418,7 +446,7 @@ Tess2Out run_tess2(const std::vector<std::vector<Uv>> &loops_uv, double su, doub
     if (loops_p3)
         out.pin.reserve(nv);
     for (int i = 0; i < nv; ++i) {
-        out.verts.push_back({tv[i * 2] / su, tv[i * 2 + 1] / sv});
+        out.verts.push_back({tv[i * 2] / su + u0, tv[i * 2 + 1] / sv + v0}); // undo the re-centering
         if (loops_p3) {
             TESSindex oi = vi ? vi[i] : TESS_UNDEF;
             out.pin.push_back((oi != TESS_UNDEF && (size_t) oi < flat_p3.size()) ? flat_p3[oi] : nan_vec());

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -123,6 +123,7 @@ struct FaceDiag {
     double emitted_area = 0;    // 3D area actually tessellated for this face
     double expected_area = 0;   // expected trimmed surface area (region-fill faces only)
     bool has_coverage = false;  // expected_area is meaningful (not a winding/periodic face)
+    size_t n_tris = 0;          // triangles emitted for this face (characterization)
 };
 
 // thread_local: DIAG forces threads=1 (see tessellate_one_root), but a stray parallel caller must
@@ -172,16 +173,16 @@ void diag_flush_face(const Surface &surf, int64_t face_id, uint32_t face_seq, do
             return;
         std::fprintf(t.fh, "face_seq,face_id,surf_kind,is_quadric,path_taken,n_bpts,n_uv_fail,n_collapsed,"
                            "r_p50,r_p95,r_max,r_rel_p50,r_rel_p95,r_rel_max,approx_size,model_scale,"
-                           "emitted_area,expected_area,coverage\n");
+                           "emitted_area,expected_area,coverage,n_tris\n");
     }
     double sz = std::max(surf.approx_size(), 1.0);
     double p50 = pct(d.r, 0.50), p95 = pct(d.r, 0.95);
     double mx = d.r.empty() ? 0.0 : *std::max_element(d.r.begin(), d.r.end());
     double coverage = (d.has_coverage && d.expected_area > 1e-12) ? d.emitted_area / d.expected_area : -1.0;
-    std::fprintf(t.fh, "%u,%lld,%s,%d,%s,%zu,%zu,%zu,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.6g,%.6g,%.4g\n",
+    std::fprintf(t.fh, "%u,%lld,%s,%d,%s,%zu,%zu,%zu,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.9g,%.6g,%.6g,%.4g,%zu\n",
                  face_seq, (long long) face_id, surf_kind(surf), (int) surf.is_quadric(), d.path, d.r.size(),
                  d.n_uv_fail, d.n_collapsed, p50, p95, mx, p50 / sz, p95 / sz, mx / sz, sz, model_scale,
-                 d.emitted_area, d.has_coverage ? d.expected_area : -1.0, coverage);
+                 d.emitted_area, d.has_coverage ? d.expected_area : -1.0, coverage, d.n_tris);
     d = FaceDiag{};
 }
 
@@ -1195,6 +1196,27 @@ bool tessellate_uv_grid(const Surface &s, double u0, double u1, double v0, doubl
                         const std::vector<Vec3> *ring_p3 = nullptr) {
     int nu, nv;
     uv_grid_res(s, nu, nv);
+    // Curvature-correct the initial resolution for quadrics (cyl/cone/sphere/torus) from the actual
+    // parametric span and the curvature step, instead of the flat 8x8 seed. refine_uv can only HALVE
+    // an edge, so an 8-division seed on a 2*pi minor circle overshoots the angular target on the way
+    // down (8->16->32->64 to reach ~36), inflating a torus band ~3x. Sizing the grid AT the target
+    // (ceil(span/u_step)) lands each edge already within the angular+chord tolerance, so refinement
+    // adds ~nothing and the band matches OCC's ring density. B-splines keep their span-based seed
+    // (their u_step is parametric, not curvature). u_step==INFINITY (flat direction) keeps the seed.
+    if (dynamic_cast<const BSplineSurface *>(&s) == nullptr) {
+        const double us = s.u_step(tp.deflection, tp.max_angle);
+        const double vs = s.v_step(tp.deflection, tp.max_angle);
+        if (std::isfinite(us) && us > 1e-12)
+            nu = (int) std::clamp((long) std::ceil(std::abs(u1 - u0) / us), 2L, 4096L);
+        if (std::isfinite(vs) && vs > 1e-12)
+            nv = (int) std::clamp((long) std::ceil(std::abs(v1 - v0) / vs), 2L, 4096L);
+        while ((long) nu * nv > 200000) {
+            if (nv > nu)
+                nv /= 2;
+            else
+                nu /= 2;
+        }
+    }
     // Grid lines. Without a ring these are exactly the uniform samples, so the default path is
     // bit-for-bit what it always was.
     std::vector<double> ul, vl;
@@ -2414,6 +2436,19 @@ bool tessellate_face_impl(const FaceSurfaceN &face, const TessParams &tp, TessMe
     bool same_sense = face.same_sense;
 
     std::vector<Loop3> loops3d = build_loops3d(face, tp);
+    // A face WITH bounds whose loops all discretized to <3 points: chord-simplification of a
+    // small/gently-curved B-spline boundary (simplify_polyline_dp) can flatten every edge to its
+    // endpoints and collapse the loop. Re-discretize progressively finer (which keeps more boundary
+    // points) before giving up, so the simplification can never drop a face that used to tessellate.
+    if (loops3d.empty() && !face.bounds.empty()) {
+        for (double div : {8.0, 64.0, 512.0}) {
+            TessParams fine = tp;
+            fine.deflection = std::max(tp.deflection / div, 1e-5);
+            loops3d = build_loops3d(face, fine);
+            if (!loops3d.empty())
+                break;
+        }
+    }
     if (loops3d.empty()) {
         if (tessellate_unbounded(surf, tp, same_sense, mesh))
             return true;
@@ -2436,24 +2471,30 @@ bool tessellate_face_impl(const FaceSurfaceN &face, const TessParams &tp, TessMe
 
     auto cp = mesh.checkpoint();
     const char *reason = face_to_mesh(use_surf, loops3d, tp, same_sense, mesh);
-    if (!reason)
+    auto produced = [&]() { return mesh.checkpoint()[1] > cp[1]; };
+    if (!reason && produced())
         return true;
 
     // recovery: a tess2 failure on a thin curved face is usually a self-intersecting boundary
-    // from coarse arc discretization — re-discretize much finer and retry.
-    bool reason_tess2 = std::string(reason).find("tess2") != std::string::npos ||
-                        std::string(reason).find("UV tessellation") != std::string::npos;
-    if (reason_tess2) {
+    // from coarse arc discretization — re-discretize much finer and retry. Also fires when the face
+    // succeeded-but-emitted-nothing: chord-simplification (simplify_polyline_dp) can over-flatten a
+    // winding/wrap boundary so a periodic/slit path misclassifies it and emits zero — the finer
+    // re-discretization restores the boundary points the wrap detection needs.
+    bool reason_tess2 = reason && (std::string(reason).find("tess2") != std::string::npos ||
+                                   std::string(reason).find("UV tessellation") != std::string::npos);
+    if (reason_tess2 || !produced()) {
         mesh.rollback(cp);
-        for (double div : {8.0, 64.0}) {
-            TessParams fine;
+        for (double div : {8.0, 64.0, 512.0}) {
+            TessParams fine = tp;
             fine.deflection = std::max(tp.deflection / div, 1e-4);
             fine.max_angle = std::max(tp.max_angle / std::sqrt(div), 0.02);
             std::vector<Loop3> fl = build_loops3d(face, fine);
-            if (fl.size() != loops3d.size())
+            // A collapsed face may have lost loops under simplification, so the finer count is the
+            // authoritative one; only bail if finer STILL yields nothing.
+            if (fl.empty())
                 continue;
             auto cp2 = mesh.checkpoint();
-            if (!face_to_mesh(use_surf, fl, fine, same_sense, mesh))
+            if (!face_to_mesh(use_surf, fl, fine, same_sense, mesh) && mesh.checkpoint()[1] > cp2[1])
                 return true;
             mesh.rollback(cp2);
         }
@@ -2544,6 +2585,7 @@ bool tessellate_face(const FaceSurfaceN &face, const TessParams &tp, TessMesh &o
         d.emitted_area = emitted_area;
         d.expected_area = fh.expected_area;
         d.has_coverage = fh.has_expected;
+        d.n_tris = (outm.indices.size() - i0) / 3;
         static std::atomic<uint32_t> g_diag_seq{0};
         diag_flush_face(*face.surface, face.src_id, g_diag_seq.fetch_add(1, std::memory_order_relaxed),
                         tls_model_scale());

--- a/src/geom/neutral/ngeom_tessellate.h
+++ b/src/geom/neutral/ngeom_tessellate.h
@@ -82,6 +82,9 @@ bool tessellate_face(const FaceSurfaceN &face, const TessParams &tp, TessMesh &o
 // the streaming entry points can report a dropped-face count for the audit to flag.
 std::uint64_t tess_dropped_faces();
 std::uint64_t tess_total_faces();
+// Faces that tessellated but covered < half their expected surface area (a partial fill / hole) —
+// present-but-incomplete geometry the zero-triangle dropped count can't catch.
+std::uint64_t tess_suspect_faces();
 void reset_tess_face_stats();
 
 // Tessellate a whole decoded document (all roots), one TessMesh with a Group per root.

--- a/src/geom/neutral/ngeom_tessellate.h
+++ b/src/geom/neutral/ngeom_tessellate.h
@@ -66,6 +66,11 @@ struct TessMesh {
         uint32_t index_count = 0; // number of indices (3 * triangles)
         int64_t face_id = 0;      // source entity id (STEP/IFC #id), 0 if unknown
         uint32_t face_seq = 0;    // 0-based face position within the solid
+        // Per-face presentation colour (from FaceSurfaceN, STEP per-face styling). has_color=false =>
+        // the face inherits the owning solid's base colour. Carried through so the GLB writer can split
+        // a solid into one primitive/material per distinct face colour (merge-by-colour at face level).
+        bool has_color = false;
+        float cr = 0.5f, cg = 0.5f, cb = 0.5f, ca = 1.0f;
     };
     std::vector<FaceRange> face_ranges;
     // Primitive topology of `indices`: TRIANGLES for solids/faces, LINES for curve-only bodies

--- a/src/geom/neutral/ngeom_topology.h
+++ b/src/geom/neutral/ngeom_topology.h
@@ -117,6 +117,78 @@ inline std::vector<Vec3> align_polyline_to_vertices(const std::vector<Vec3> &pts
     return std::vector<Vec3>{a, b}; // ia == ib: sub-range within one sample interval
 }
 
+// Chord-deflection simplification of a sampled polyline (Douglas-Peucker). The uniform B-spline
+// edge sampler (uniform_edge_segments) emits a fixed cps*4 points REGARDLESS of tolerance, so a
+// coarse `deflection` never coarsens a B-spline boundary — the dominant source of native's
+// over-tessellation on freeform faces (a face's boundary alone can carry thousands of points, each
+// forcing a CDT triangle the interior refinement then multiplies). Decimating the sampled polyline
+// down to the chord tolerance makes the boundary honour `deflection` like OCC's edge discretization.
+//
+// Douglas-Peucker is used (not a greedy forward walk) because it is DIRECTION-SYMMETRIC: the two
+// faces sharing a manifold edge discretize it in opposite orders, and DP keeps the same point SET
+// either way (the recursive max-deviation split does not depend on traversal direction), so the
+// shared edge stays watertight. Endpoints are always kept. tol<=0 disables (keeps every sample).
+inline std::vector<Vec3> simplify_polyline_dp(const std::vector<Vec3> &p, double tol, double max_angle) {
+    const size_t n = p.size();
+    if (n <= 2 || tol <= 0.0)
+        return p;
+    const double cos_ang = (max_angle > 0.0) ? std::cos(max_angle) : -2.0; // -2 => angle test off
+    std::vector<char> keep(n, 0);
+    keep[0] = keep[n - 1] = 1;
+    // explicit stack of [i,j] ranges whose chord approximates the interior within tol or gets split
+    std::vector<std::pair<size_t, size_t>> stk;
+    stk.emplace_back(0, n - 1);
+    while (!stk.empty()) {
+        auto [i, j] = stk.back();
+        stk.pop_back();
+        if (j <= i + 1)
+            continue;
+        const Vec3 A = p[i], B = p[j];
+        const Vec3 ab = B - A;
+        const double abl2 = ab.dot(ab);
+        double dmax = -1.0;
+        size_t im = i;
+        for (size_t k = i + 1; k < j; ++k) {
+            const Vec3 d = p[k] - A;
+            double sag;
+            if (abl2 < 1e-24)
+                sag = d.norm(); // degenerate chord (closed edge): distance to the shared endpoint
+            else {
+                const double t = d.dot(ab) / abl2; // UNCLAMPED perpendicular distance (standard DP)
+                sag = (d - ab * t).norm();
+            }
+            if (sag > dmax) {
+                dmax = sag;
+                im = k;
+            }
+        }
+        // Angular criterion (keeps curved boundaries — e.g. a tube's end ring — ROUND rather than
+        // letting a within-sag chord octagonalize them, matching OCC's edge angular deflection). The
+        // turn across the chord is measured from the ORIGINAL segments at each end, so it is
+        // reversal-symmetric; the split point (max perpendicular deviation) is symmetric too, so the
+        // decimated point SET is identical whichever direction the two adjacent faces walk the edge.
+        bool angle_split = false;
+        if (cos_ang > -1.5) {
+            const Vec3 d0 = p[i + 1] - p[i];
+            const Vec3 d1 = p[j] - p[j - 1];
+            const double l0 = d0.norm(), l1 = d1.norm();
+            if (l0 > 1e-12 && l1 > 1e-12 && d0.dot(d1) / (l0 * l1) < cos_ang)
+                angle_split = true;
+        }
+        if ((dmax > tol || angle_split) && im > i) {
+            keep[im] = 1;
+            stk.emplace_back(i, im);
+            stk.emplace_back(im, j);
+        }
+    }
+    std::vector<Vec3> out;
+    out.reserve(n);
+    for (size_t k = 0; k < n; ++k)
+        if (keep[k])
+            out.push_back(p[k]);
+    return out;
+}
+
 // One oriented edge of a loop. `start`/`end` are the EDGE_CURVE endpoints with the ORIENTED_EDGE
 // orientation already applied (decode). `e_start`/`e_end` are the raw EDGE_CURVE endpoints and
 // `same_sense`/`orientation` the flags — needed because a *closed* circle/ellipse edge (start==end)
@@ -198,6 +270,9 @@ struct OrientedEdgeN {
                 std::reverse(pts.begin(), pts.end());
             pts.front() = start;
             pts.back() = end;
+            // Decimate the fixed-density B-spline sample to the chord tolerance (see
+            // simplify_polyline_dp): this is what makes a B-spline boundary respond to `deflection`.
+            pts = simplify_polyline_dp(pts, deflection, max_angle);
             return pts;
         } else {
             handled = false;

--- a/src/geom/neutral/ngeom_topology.h
+++ b/src/geom/neutral/ngeom_topology.h
@@ -317,6 +317,12 @@ struct FaceSurfaceN {
     // real 3D plane is only implied by its boundary points). The tessellator must fit the plane from
     // the 3D loop up front — otherwise the poly projects flat onto the z=0 placeholder plane.
     bool fit_plane_from_loop = false;
+    // Per-face presentation colour (STEP OVER_RIDING_STYLED_ITEM -> COLOUR_RGB, keyed on this face's
+    // ADVANCED_FACE #id). Mirrors NgeomRoot's per-solid colour. has_color=false => the face inherits the
+    // owning solid's base colour. Populated by the native STEP reader (step_reader.h face()); the neutral
+    // decoder / IFC path leave it unset.
+    bool has_color = false;
+    float cr = 0.5f, cg = 0.5f, cb = 0.5f, ca = 1.0f; // rgba in 0..1 when has_color
 };
 
 struct ConnectedFaceSetN {


### PR DESCRIPTION
## Summary

A native, OpenCASCADE-free STEP/IFC → GLB conversion pipeline: a dependency-free STEP/IFC reader, an `ng::` neutral geometry layer, a libtess2-based boundary tessellator with selectable tessellation tracks, and a C++ GLB writer with per-face clickable regions. This branch brings the native path to geometry and colour parity with OpenCASCADE on curved-surface-heavy models, while running faster and at lower memory.

## Highlights

**Native pipeline**
- OCC-free STEP and IFC readers, an `ng::` neutral geometry layer, and a C++ GLB writer (per-instance picking, full assembly tree, per-face regions).
- Selectable tessellation tracks (libtess2 boundary CDT + taxonomy kernels), boundary pinning on by default; forwarded through the STEP and IFC bindings.

**Curved-surface geometry fidelity**
- Closed/periodic B-spline surfaces now honour the STEP `closed_u`/`closed_v` flags and tessellate correctly (periodic evaluation by wrapping instead of clamping) — previously they collapsed to degenerate slivers covering a fraction of their true area.
- Periodic tube faces are de-twisted: the band tessellation uses a structured arc-length loft (aligned rings) instead of a CDT that spiraled, watertight (only original ring vertices, no Steiner points).
- Robust surface-of-revolution UV inversion, quadric face-side selection by STEP orientation, and v-winding torus/tube band handling.

**Colour fidelity**
- Per-face STEP colours read from `STYLED_ITEM` **including** `OVER_RIDING_STYLED_ITEM` (previously ~99% of per-face styling on override-heavy files was dropped), split into one material per distinct face colour.
- sRGB → linear conversion for glTF `baseColorFactor` (glTF is linear space; STEP `COLOUR_RGB` is sRGB) — fixes warm colours rendering shifted (e.g. orange appearing yellow).

**Tessellation efficiency**
- Cut libtess2 over-tessellation by ~3–4×: boundary discretization is now bounded by both chord (linear deflection) and angular tolerance — it was previously tolerance-independent — and quadric grids are curvature-sized to avoid bisection overshoot.

## Validation

Measured on a reference STEP model and a large ~300K-face STEP assembly (identical flags, native path):
- Geometry and colour parity with OpenCASCADE on curved surfaces; 0 dropped faces on the reference model.
- ~63–73% fewer triangles, GLB 3–3.6× smaller, 1.3–4.3× faster conversion, and lower peak memory — with no out-of-memory on the large assembly (where the OpenCASCADE loader OOMs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
