### PR TITLE
fix: per-face STEP colours without --face-regions, plus CLI positional args + pipeline validation

### DIFF
--- a/src/cad/step_to_glb_stream.h
+++ b/src/cad/step_to_glb_stream.h
@@ -90,8 +90,13 @@ inline long stream_step_to_glb(const std::string &in_path, const std::string &ou
         tp.libtess2.converged_frac = std::atof(e);
     tp.deflection = deflection;
     tp.max_angle = angular_deg * 3.14159265358979323846 / 180.0;
-    tp.model_scale = model_scale;          // >0 => adaptive per-surface density; the per-solid tpp copies inherit it
-    tp.capture_face_ranges = face_regions; // opt-in per-face clickable regions -> scenes[0].extras
+    tp.model_scale = model_scale; // >0 => adaptive per-surface density; the per-solid tpp copies inherit it
+    // Always capture per-face ranges: split_solid_by_face_colour needs each face's colour + triangle
+    // range to bucket AP214 per-face styling into per-colour materials, independent of the picking
+    // opt-in. The picking EXTRAS (face_ranges_node<m>) stay gated on `face_regions` — the ranges are
+    // dropped after the colour split when they weren't requested (process_root below). Capture is now
+    // parallel-safe (recorded in the tessellator's in-order merge), so this keeps big files parallel.
+    tp.capture_face_ranges = true;
 
     // Metadata (colour/transform/path maps) once; workers copy these read-only maps.
     adacpp::step::Resolver master(idx);
@@ -222,8 +227,11 @@ inline long stream_step_to_glb(const std::string &in_path, const std::string &ou
                 }
                 // A solid whose faces carry distinct per-face colours (AP214 per-face styling) is split
                 // into one primitive/material per colour; single-colour solids pass through unchanged.
-                for (adacpp::glb::GlbSolid &part : adacpp::glb::split_solid_by_face_colour(gs))
-                    lane.add(part); // spilled to disk immediately
+                for (adacpp::glb::GlbSolid &part : adacpp::glb::split_solid_by_face_colour(gs)) {
+                    if (!face_regions)
+                        part.face_ranges.clear(); // colour split done; drop picking ranges (opt-in extras)
+                    lane.add(part);               // spilled to disk immediately
+                }
                 nwritten.fetch_add(1, std::memory_order_relaxed);
             };
             // Phase A — the huge prefix, one root at a time BEFORE the pool starts: every thread

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -3198,7 +3198,10 @@ static void tessellate_one_root(const NgeomRoot &root, const TessParams &tp, Tes
         // the serial loop. The 64-face floor keeps small solids on the cheap path.
         // DIAG forces the serial loop: the per-face residual accumulator is thread_local, so a
         // face-parallel run would scatter rows across threads and lose the face-order sequence.
-        if (tp.threads > 1 && root.faces.size() >= 64 && !tp.capture_face_ranges && !DIAG) {
+        // Face-range capture happens in the in-order merge below, so it no longer forces the serial
+        // path — big colour-bearing solids stay parallel. DIAG still forces serial (its per-face
+        // residual accumulator is thread_local and would scatter across face workers).
+        if (tp.threads > 1 && root.faces.size() >= 64 && !DIAG) {
             const size_t n = root.faces.size();
             TessParams tpl = tp;
             tpl.threads = 1; // no nested pools inside a face
@@ -3235,8 +3238,24 @@ static void tessellate_one_root(const NgeomRoot &root, const TessParams &tp, Tes
                 face_worker();
                 for (std::thread &th : pool)
                     th.join();
-                for (const TessMesh &lm : locals)
-                    append_mesh(out, lm);
+                // Merge in face order (identical to the serial loop). Capture per-face ranges HERE
+                // when requested, measuring each face's [start,count) as it lands in the merged
+                // buffer — same result as the serial capture path, but without giving up parallelism.
+                for (size_t li = 0; li < locals.size(); ++li) {
+                    const size_t fi = b0 + li;
+                    if (tp.capture_face_ranges && root.faces[fi]) {
+                        const uint32_t s = (uint32_t) out.indices.size();
+                        append_mesh(out, locals[li]);
+                        const uint32_t c = (uint32_t) out.indices.size() - s;
+                        if (c > 0) {
+                            const auto &f = *root.faces[fi];
+                            out.face_ranges.push_back(
+                                {s, c, f.src_id, (uint32_t) fi, f.has_color, f.cr, f.cg, f.cb, f.ca});
+                        }
+                    } else {
+                        append_mesh(out, locals[li]);
+                    }
+                }
             } // locals freed here -> next batch's peak is one batch, not all n faces
             return;
         }

--- a/src/stp2glb/main.cpp
+++ b/src/stp2glb/main.cpp
@@ -30,8 +30,10 @@ int main(int argc, char *argv[]) {
     double model_scale = 0.0;  // >0 => adaptive per-surface density (relaxes tiny features); 0 => fixed
     std::string spill_dir;     // empty => private auto-removed mkdtemp spill dir
 
-    app.add_option("--stp", stp_file, "STEP input filepath")->required();
-    app.add_option("--glb", glb_file, "GLB output filepath")->required();
+    // Positional first (STP2GLB input.stp output.glb) — the natural CLI shape; --stp/--glb are kept
+    // as named aliases for back-compat with existing scripts.
+    app.add_option("stp,--stp", stp_file, "STEP input filepath (positional or --stp)")->required();
+    app.add_option("glb,--glb", glb_file, "GLB output filepath (positional or --glb)")->required();
     // --lin-defl kept as an alias for backwards compatibility with the old OCCT CLI.
     app.add_option("--deflection,--lin-defl", deflection, "Linear deflection")->default_val(2.0);
     app.add_option("--angular-deg", angular_deg, "Angular deflection (degrees)")->default_val(20.0);
@@ -40,7 +42,18 @@ int main(int argc, char *argv[]) {
     app.add_flag("--profile", profile, "Print [STEPPROF] phase/memory/per-solid timing to stderr (StepProfiler)");
     app.add_flag("--face-regions", face_regions,
                  "Bake per-face clickable regions into scenes[0].extras (face_ranges_node<m>); opt-in");
-    app.add_option("--pipeline", pipeline, "Tessellation track: libtess2 (default) | cdt | occ | cgal | hybrid");
+    // Only the NEUTRAL tracks mesh the OCC-free native path this CLI drives. occ/cgal/hybrid are
+    // ifcopenshell-taxonomy kernels this build cannot run — handed to the neutral path they silently
+    // emit libtess2 output, so advertising them would be a lie. Restrict --pipeline to the neutral
+    // set derived from track_infos() (so the two can't drift), and reject the rest with a clear error.
+    std::vector<std::string> neutral_tracks;
+    std::string pipeline_help = "Tessellation track (OCC-free native):";
+    for (const auto &t : adacpp::ngeom::track_infos())
+        if (t.neutral) {
+            neutral_tracks.emplace_back(t.name);
+            pipeline_help += std::string(" ") + t.name + (t.is_default ? " (default)" : "");
+        }
+    app.add_option("--pipeline", pipeline, pipeline_help)->check(CLI::IsMember(neutral_tracks));
     app.add_flag("--pin-boundary,!--no-pin-boundary", pin_boundary,
                  "libtess2: emit boundary vertices at their shared-edge point instead of this face's own "
                  "surface re-projection (default ON; halves cracks for ~3%)");


### PR DESCRIPTION
## Summary

Two fixes on top of v0.16.0, cut from `main`.

### Per-face colours no longer require `--face-regions`
Per-face STEP styling (AP214 `OVER_RIDING_STYLED_ITEM`) is split into one material per colour by `split_solid_by_face_colour`, but that consumed the per-face ranges captured **only** under `--face-regions`. So a plain `STP2GLB in.stp out.glb` fell back to one base colour per solid — an assembly rendered mostly a single colour instead of its full palette.

Colour is a rendering property, not a picking one, so it's decoupled: per-face ranges are now **always** captured (they carry each face's colour), and only the `face_ranges_node<m>` picking extras stay gated on `--face-regions` (the ranges are dropped after the colour split when picking wasn't requested). Capture moved into the tessellator's in-order **parallel** merge, so it no longer forces serial tessellation — `--face-regions` conversions also get faster and large files stay parallel. `dropped_faces` is unchanged and the picking contract is intact when requested.

### CLI ergonomics
- STP2GLB now takes the STEP and GLB paths **positionally** (`STP2GLB in.stp out.glb`); `--stp` / `--glb` remain as named aliases for back-compat.
- `--pipeline` advertised `occ` / `cgal` / `hybrid`, but this OCC-free CLI can't run the ifcopenshell taxonomy kernels — handed one, the neutral path silently emitted the default `libtess2` output. `--pipeline` is now restricted to the neutral tracks derived from `track_infos()` (`libtess2` | `cdt`) and rejects the rest with a clear error, so the CLI no longer advertises kernels it can't run.

## Validation
- A reference STEP model: a plain conversion now yields the full material palette (was a single base colour per solid); `--face-regions` yields the same palette plus the picking extras.
- Conversion of that model dropped from ~8s (serial capture) to ~2.8s (parallel capture).
- `dropped_faces = 0` both with and without `--face-regions`.
- CLI: positional and `--stp`/`--glb` both work; `--pipeline occ` is rejected; `--help` lists only the runnable tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
