### PR TITLE
feat: AP242 mapped instancing and closed-B-spline tessellation fixes

### DIFF
--- a/src/adacpp/cad/__init__.py
+++ b/src/adacpp/cad/__init__.py
@@ -130,7 +130,9 @@ step_emit_ifc_brep = _cad.step_emit_ifc_brep
 step_parity = _cad.step_parity
 stream_ifc_to_glb = _cad.stream_ifc_to_glb
 stream_ifc_to_step = _cad.stream_ifc_to_step
+stream_ngeom_to_glb = _cad.stream_ngeom_to_glb
 stream_ngeom_to_ifc = _cad.stream_ngeom_to_ifc
+stream_ngeom_to_mesh = _cad.stream_ngeom_to_mesh
 stream_ngeom_to_step = _cad.stream_ngeom_to_step
 stream_step_to_glb = _cad.stream_step_to_glb
 stream_step_to_glb_st = _cad.stream_step_to_glb_st
@@ -251,7 +253,9 @@ __all__ = [
     "step_parity",
     "stream_ifc_to_glb",
     "stream_ifc_to_step",
+    "stream_ngeom_to_glb",
     "stream_ngeom_to_ifc",
+    "stream_ngeom_to_mesh",
     "stream_ngeom_to_step",
     "stream_step_to_glb",
     "stream_step_to_glb_st",

--- a/src/adacpp/cad/__init__.py
+++ b/src/adacpp/cad/__init__.py
@@ -129,6 +129,8 @@ step_emit_ifc_brep = _cad.step_emit_ifc_brep
 step_parity = _cad.step_parity
 stream_ifc_to_glb = _cad.stream_ifc_to_glb
 stream_ifc_to_step = _cad.stream_ifc_to_step
+stream_ngeom_to_ifc = _cad.stream_ngeom_to_ifc
+stream_ngeom_to_step = _cad.stream_ngeom_to_step
 stream_step_to_glb = _cad.stream_step_to_glb
 stream_step_to_glb_st = _cad.stream_step_to_glb_st
 stream_step_to_ifc = _cad.stream_step_to_ifc
@@ -247,6 +249,8 @@ __all__ = [
     "step_parity",
     "stream_ifc_to_glb",
     "stream_ifc_to_step",
+    "stream_ngeom_to_ifc",
+    "stream_ngeom_to_step",
     "stream_step_to_glb",
     "stream_step_to_glb_st",
     "stream_step_to_ifc",

--- a/src/adacpp/cad/__init__.py
+++ b/src/adacpp/cad/__init__.py
@@ -111,6 +111,7 @@ meshopt_decode_vertex_buffer = _cad.meshopt_decode_vertex_buffer
 meshopt_encode_index_sequence = _cad.meshopt_encode_index_sequence
 meshopt_encode_vertex_buffer = _cad.meshopt_encode_vertex_buffer
 meshopt_simplify_mesh = _cad.meshopt_simplify_mesh
+ngeom_to_ifc_body_spf = _cad.ngeom_to_ifc_body_spf
 non_manifold_merge = _cad.non_manifold_merge
 obb = _cad.obb
 point_in_solid = _cad.point_in_solid
@@ -231,6 +232,7 @@ __all__ = [
     "meshopt_encode_index_sequence",
     "meshopt_encode_vertex_buffer",
     "meshopt_simplify_mesh",
+    "ngeom_to_ifc_body_spf",
     "non_manifold_merge",
     "obb",
     "point_in_solid",

--- a/src/cad/brep_file_convert.h
+++ b/src/cad/brep_file_convert.h
@@ -321,19 +321,19 @@ inline long emit_solid_step(adacpp::step_emit::StepBrepEmitter &em, std::string 
     if (root.extrusion) {
         bool hollow = root.extrusion->profile && root.extrusion->profile->bounds.size() > 1;
         if (em.tf_rigid() && !hollow) { // rigid, solid profile -> native EXTRUDED_AREA_SOLID
-            solid = em.emit_extrusion(buf, *root.extrusion);
+            solid = em.emit_extrusion(buf, *root.extrusion, nm);
             rep_kw = "SHAPE_REPRESENTATION";
         } else { // scale/shear or hollow profile -> bake to a B-rep (annular caps for voids)
             solid = em.emit_extrusion_baked(buf, *root.extrusion, nm);
         }
     } else if (root.revolve) { // non-rigid revolves are dropped to OCC by the reader -> rigid here
-        solid = em.emit_revolve(buf, *root.revolve);
+        solid = em.emit_revolve(buf, *root.revolve, nm);
         rep_kw = "SHAPE_REPRESENTATION";
     } else if (root.sweep) { // disk/annulus swept along a directrix -> SWEPT_DISK_SOLID
-        solid = em.emit_swept_disk(buf, *root.sweep);
+        solid = em.emit_swept_disk(buf, *root.sweep, nm);
         rep_kw = "SHAPE_REPRESENTATION";
     } else if (root.sphere) { // CSG sphere primitive
-        solid = em.emit_sphere(buf, *root.sphere);
+        solid = em.emit_sphere(buf, *root.sphere, nm);
         rep_kw = "SHAPE_REPRESENTATION";
     } else if (root.boolean) { // CSG tree (BOOLEAN_RESULT), preserved not evaluated
         solid = em.emit_boolean(buf, *root.boolean);
@@ -485,45 +485,76 @@ inline void emit_step_mapped_instances(adacpp::step_emit::StepBrepEmitter &em, s
     }
 }
 
-// Emit a NEXT_ASSEMBLY_USAGE_OCCURRENCE assembly tree from per-leaf (product_definition, path): each
-// intermediate path level becomes an assembly PRODUCT_DEFINITION, linked to its children (assemblies or
-// leaf solids) by a NAUO — the STEP counterpart of emit_spatial_tree, so the IFC/STEP hierarchy round-
-// trips. Assembly nodes carry no own shape (grouping only); placements stay baked into the leaf geometry.
+// Emit a NEXT_ASSEMBLY_USAGE_OCCURRENCE assembly tree from per-leaf (product_definition, rep,
+// path): each intermediate path level becomes an assembly PRODUCT with its OWN (empty, identity-
+// axis) SHAPE_REPRESENTATION, and every parent->child link is the full AP242 occurrence record —
+// NAUO + PRODUCT_DEFINITION_SHAPE + identity ITEM_DEFINED_TRANSFORMATION + complex
+// REPRESENTATION_RELATIONSHIP(child_rep, parent_rep) + CONTEXT_DEPENDENT_SHAPE_REPRESENTATION —
+// the STEP counterpart of emit_spatial_tree and the exact pattern adapy's ap242_stream writer
+// emits. The CDSR/RR records matter: without them OCC's STEP reader finds no geometry under the
+// (shapeless) assembly products and transfers an empty model; with them both native stream
+// readers ALSO recover the assembly paths. Placements stay baked into the leaf geometry
+// (identity occurrence transforms). `identity_axis_id` is the shared header AXIS2 (#13).
 using IfcPath2 = std::vector<std::pair<int, std::string>>;
 inline void emit_step_assembly_tree(adacpp::step_emit::StepBrepEmitter &em, std::string &buf,
-                                    const std::vector<long> &leaf_pds, const std::vector<IfcPath2> &paths) {
+                                    const std::vector<long> &leaf_pds, const std::vector<long> &leaf_reps,
+                                    const std::vector<IfcPath2> &paths, long identity_axis_id = 13) {
     using adacpp::ifc_emit::ifc_str;
-    std::map<std::vector<int>, long> asm_pd; // rep-id prefix -> assembly PRODUCT_DEFINITION id
-    auto asm_node = [&](const std::vector<int> &prefix, const std::string &name) -> long {
-        auto it = asm_pd.find(prefix);
-        if (it != asm_pd.end())
+    auto ref = [](long id) { return "#" + std::to_string(id); };
+    struct AsmNode {
+        long pd = 0, rep = 0;
+    };
+    std::map<std::vector<int>, AsmNode> asm_nodes; // rep-id prefix -> assembly node
+    bool asm_created = false;                      // set by asm_node when the last call minted a new node
+    auto asm_node = [&](const std::vector<int> &prefix, const std::string &name) -> AsmNode {
+        auto it = asm_nodes.find(prefix);
+        asm_created = it == asm_nodes.end();
+        if (!asm_created)
             return it->second;
         std::string nm = name.empty() ? ("asm_" + std::to_string(prefix.back())) : ifc_str(name);
+        AsmNode n;
+        n.rep = em.emit_entity(buf, "SHAPE_REPRESENTATION('" + nm + "',(" + ref(identity_axis_id) + "),#9)");
         long product = em.emit_entity(buf, "PRODUCT('" + nm + "','" + nm + "','',(#3))");
         long pdf = em.emit_entity(buf, "PRODUCT_DEFINITION_FORMATION('','',#" + std::to_string(product) + ")");
-        long pd = em.emit_entity(buf, "PRODUCT_DEFINITION('design','',#" + std::to_string(pdf) + ",#4)");
-        asm_pd[prefix] = pd;
-        return pd;
+        n.pd = em.emit_entity(buf, "PRODUCT_DEFINITION('design','',#" + std::to_string(pdf) + ",#4)");
+        long pds = em.emit_entity(buf, "PRODUCT_DEFINITION_SHAPE('','',#" + std::to_string(n.pd) + ")");
+        em.emit_entity(buf,
+                       "SHAPE_DEFINITION_REPRESENTATION(#" + std::to_string(pds) + ",#" + std::to_string(n.rep) + ")");
+        asm_nodes[prefix] = n;
+        return n;
     };
-    auto nauo = [&](long parent_pd, long child_pd, const std::string &nm) {
-        em.emit_entity(buf, "NEXT_ASSEMBLY_USAGE_OCCURRENCE('','" + nm + "','',#" + std::to_string(parent_pd) + ",#" +
-                                std::to_string(child_pd) + ",$)");
+    // Full occurrence link (identity placement): NAUO + PDS + IDT + complex-RR + CDSR. A child
+    // with no representation id (defensive; shouldn't happen) gets the bare NAUO only.
+    auto nauo = [&](const AsmNode &parent, long child_pd, long child_rep, const std::string &nm) {
+        long id = em.emit_entity(buf, "NEXT_ASSEMBLY_USAGE_OCCURRENCE('','" + nm + "','',#" +
+                                          std::to_string(parent.pd) + "," + ref(child_pd) + ",$)");
+        if (!child_rep)
+            return;
+        long pds = em.emit_entity(buf, "PRODUCT_DEFINITION_SHAPE('',''," + ref(id) + ")");
+        long idt = em.emit_entity(buf, "ITEM_DEFINED_TRANSFORMATION('',''," + ref(identity_axis_id) + "," +
+                                           ref(identity_axis_id) + ")");
+        long rr = em.emit_entity(buf, "(REPRESENTATION_RELATIONSHIP('',''," + ref(child_rep) + "," + ref(parent.rep) +
+                                          ")REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(" + ref(idt) +
+                                          ")SHAPE_REPRESENTATION_RELATIONSHIP())");
+        em.emit_entity(buf, "CONTEXT_DEPENDENT_SHAPE_REPRESENTATION(" + ref(rr) + "," + ref(pds) + ")");
     };
     for (size_t i = 0; i < leaf_pds.size(); ++i) {
         if (!leaf_pds[i])
             continue;
         const IfcPath2 &path = (i < paths.size()) ? paths[i] : IfcPath2{};
-        long parent_pd = 0;
+        AsmNode parent{};
         std::vector<int> prefix;
         for (size_t d = 0; d + 1 < path.size(); ++d) {
             prefix.push_back(path[d].first);
-            long apd = asm_node(prefix, path[d].second);
-            if (parent_pd)
-                nauo(parent_pd, apd, path[d].second);
-            parent_pd = apd;
+            AsmNode node = asm_node(prefix, path[d].second);
+            // Link an assembly to its parent ONCE (on creation) — per-leaf linking duplicated the
+            // assembly-assembly NAUO for every additional leaf sharing the branch.
+            if (parent.pd && asm_created)
+                nauo(parent, node.pd, node.rep, path[d].second);
+            parent = node;
         }
-        if (parent_pd) // hang the leaf solid under its deepest assembly (top-level leaves stay roots)
-            nauo(parent_pd, leaf_pds[i], path.empty() ? "" : path.back().second);
+        if (parent.pd) // hang the leaf solid under its deepest assembly (top-level leaves stay roots)
+            nauo(parent, leaf_pds[i], i < leaf_reps.size() ? leaf_reps[i] : 0, path.empty() ? "" : path.back().second);
     }
 }
 
@@ -563,6 +594,7 @@ inline adacpp::ifc_emit::FileStats write_ifc_to_step_impl(const std::string &in_
         }
     };
     std::vector<long> leaf_pds;       // per emitted solid: its PRODUCT_DEFINITION id (for the NAUO tree)
+    std::vector<long> leaf_reps;      // parallel: its SHAPE_REPRESENTATION id (the CDSR child rep)
     std::vector<IfcPath2> leaf_paths; // parallel: the solid's assembly path
     for (long pid : roots) {
         NgeomRoot root = r.resolve_product(pid);
@@ -594,11 +626,13 @@ inline adacpp::ifc_emit::FileStats write_ifc_to_step_impl(const std::string &in_
                 tfp = tf;
             }
             StepBrepEmitter em(nid, tfp, deflection, angular_deg);
-            long pd = emit_solid_step(em, buf, root, pid);
+            long rep_id = 0;
+            long pd = emit_solid_step(em, buf, root, pid, &rep_id);
             if (pd) {
                 nid = em.current_id();
                 any = true;
                 leaf_pds.push_back(pd);
+                leaf_reps.push_back(rep_id);
                 leaf_paths.push_back(k < root.instance_paths.size() ? root.instance_paths[k] : IfcPath2{});
                 const auto &s = em.stats();
                 fs.geom.faces_in += s.faces_in;
@@ -618,7 +652,7 @@ inline adacpp::ifc_emit::FileStats write_ifc_to_step_impl(const std::string &in_
     prof.phase("resolve+emit");
     // NAUO assembly tree over all emitted leaves (STEP counterpart of the IFC spatial tree).
     StepBrepEmitter emtree(nid, nullptr, deflection, angular_deg);
-    emit_step_assembly_tree(emtree, buf, leaf_pds, leaf_paths);
+    emit_step_assembly_tree(emtree, buf, leaf_pds, leaf_reps, leaf_paths);
     const char *foot = "ENDSEC;\nEND-ISO-10303-21;\n";
     buf += foot;
     flush(true);

--- a/src/cad/brep_file_convert.h
+++ b/src/cad/brep_file_convert.h
@@ -310,8 +310,11 @@ inline std::string step_header_block(double unit_scale) {
 // Returns the leaf PRODUCT_DEFINITION id (0 on failure) so the caller can hang a NEXT_ASSEMBLY_USAGE_
 // OCCURRENCE assembly tree off it; treat nonzero as success. `rep_out` (optional) receives the id of
 // the solid's SHAPE_REPRESENTATION — the mapped-instance emitter needs it as the CDSR child rep.
+// `solid_out` (optional) receives the id of the solid geometry item itself (the MANIFOLD_SOLID_BREP /
+// EXTRUDED_AREA_SOLID / ...) — the presentation-colour emitter styles that item.
 inline long emit_solid_step(adacpp::step_emit::StepBrepEmitter &em, std::string &buf,
-                            const adacpp::ngeom::NgeomRoot &root, long sid, long *rep_out = nullptr) {
+                            const adacpp::ngeom::NgeomRoot &root, long sid, long *rep_out = nullptr,
+                            long *solid_out = nullptr) {
     std::string nm = root.id.empty() ? ("solid_" + std::to_string(sid)) : adacpp::ifc_emit::ifc_str(root.id);
     long solid = 0;
     const char *rep_kw = "ADVANCED_BREP_SHAPE_REPRESENTATION";
@@ -340,6 +343,8 @@ inline long emit_solid_step(adacpp::step_emit::StepBrepEmitter &em, std::string 
     }
     if (!solid)
         return 0;
+    if (solid_out)
+        *solid_out = solid;
     long rep = em.emit_entity(buf, std::string(rep_kw) + "('" + nm + "',(#13,#" + std::to_string(solid) + "),#9)");
     if (rep_out)
         *rep_out = rep;
@@ -349,6 +354,36 @@ inline long emit_solid_step(adacpp::step_emit::StepBrepEmitter &em, std::string 
     long pds = em.emit_entity(buf, "PRODUCT_DEFINITION_SHAPE('','',#" + std::to_string(pd) + ")");
     em.emit_entity(buf, "SHAPE_DEFINITION_REPRESENTATION(#" + std::to_string(pds) + ",#" + std::to_string(rep) + ")");
     return pd;
+}
+
+// AP242 presentation colour for one geometry item: the STYLED_ITEM chain (COLOUR_RGB ->
+// FILL_AREA_STYLE_COLOUR -> ... -> PRESENTATION_STYLE_ASSIGNMENT -> STYLED_ITEM), matching adapy's
+// Python ap242_stream writer (_emit_color) so downstream consumers see the same records. Returns the
+// STYLED_ITEM id; the caller collects them for step_color_trailer.
+inline long emit_step_color(adacpp::step_emit::StepBrepEmitter &em, std::string &buf, long item_id, float r, float g,
+                            float b) {
+    using adacpp::ifc_emit::ifc_real;
+    auto ref = [](long id) { return "#" + std::to_string(id); };
+    long col = em.emit_entity(buf, "COLOUR_RGB(''," + ifc_real(r) + "," + ifc_real(g) + "," + ifc_real(b) + ")");
+    long fac = em.emit_entity(buf, "FILL_AREA_STYLE_COLOUR(''," + ref(col) + ")");
+    long fas = em.emit_entity(buf, "FILL_AREA_STYLE('',(" + ref(fac) + "))");
+    long ssfa = em.emit_entity(buf, "SURFACE_STYLE_FILL_AREA(" + ref(fas) + ")");
+    long sss = em.emit_entity(buf, "SURFACE_SIDE_STYLE('',(" + ref(ssfa) + "))");
+    long ssu = em.emit_entity(buf, "SURFACE_STYLE_USAGE(.BOTH.," + ref(sss) + ")");
+    long psa = em.emit_entity(buf, "PRESENTATION_STYLE_ASSIGNMENT((" + ref(ssu) + "))");
+    return em.emit_entity(buf, "STYLED_ITEM('color',(" + ref(psa) + ")," + ref(item_id) + ")");
+}
+
+// The one-per-file presentation trailer over every STYLED_ITEM (context #9). No-op when empty.
+inline void step_color_trailer(adacpp::step_emit::StepBrepEmitter &em, std::string &buf,
+                               const std::vector<long> &styled_ids) {
+    if (styled_ids.empty())
+        return;
+    std::string refs = "(";
+    for (size_t i = 0; i < styled_ids.size(); ++i)
+        refs += (i ? ",#" : "#") + std::to_string(styled_ids[i]);
+    refs += ")";
+    em.emit_entity(buf, "MECHANICAL_DESIGN_GEOMETRIC_PRESENTATION_REPRESENTATION(''," + refs + ",#9)");
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/src/cad/brep_file_convert.h
+++ b/src/cad/brep_file_convert.h
@@ -434,10 +434,9 @@ inline void emit_step_mapped_instances(adacpp::step_emit::StepBrepEmitter &em, s
         long loc = em.emit_entity(buf, "CARTESIAN_POINT('',(" + R(T[12]) + "," + R(T[13]) + "," + R(T[14]) + "))");
         long az = em.emit_entity(buf, "DIRECTION('',(" + R(T[8]) + "," + R(T[9]) + "," + R(T[10]) + "))");
         long ax = em.emit_entity(buf, "DIRECTION('',(" + R(T[0]) + "," + R(T[1]) + "," + R(T[2]) + "))");
-        long axis =
-            em.emit_entity(buf, "AXIS2_PLACEMENT_3D(''," + ref(loc) + "," + ref(az) + "," + ref(ax) + ")");
-        long idt = em.emit_entity(
-            buf, "ITEM_DEFINED_TRANSFORMATION('',''," + ref(identity_axis_id) + "," + ref(axis) + ")");
+        long axis = em.emit_entity(buf, "AXIS2_PLACEMENT_3D(''," + ref(loc) + "," + ref(az) + "," + ref(ax) + ")");
+        long idt =
+            em.emit_entity(buf, "ITEM_DEFINED_TRANSFORMATION('',''," + ref(identity_axis_id) + "," + ref(axis) + ")");
         long rr = em.emit_entity(buf, "(REPRESENTATION_RELATIONSHIP('',''," + ref(rep_id) + "," + ref(world_rep_id) +
                                           ")REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(" + ref(idt) +
                                           ")SHAPE_REPRESENTATION_RELATIONSHIP())");

--- a/src/cad/brep_file_convert.h
+++ b/src/cad/brep_file_convert.h
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <functional>
 #include <map>
 #include <string>
@@ -307,9 +308,10 @@ inline std::string step_header_block(double unit_scale) {
 // MANIFOLD_SOLID_BREP / EXTRUDED_AREA_SOLID -> (ADVANCED_BREP_)SHAPE_REPRESENTATION (placement #13,
 // context #9) -> PRODUCT chain -> SHAPE_DEFINITION_REPRESENTATION. Returns true if a solid was emitted.
 // Returns the leaf PRODUCT_DEFINITION id (0 on failure) so the caller can hang a NEXT_ASSEMBLY_USAGE_
-// OCCURRENCE assembly tree off it; treat nonzero as success.
+// OCCURRENCE assembly tree off it; treat nonzero as success. `rep_out` (optional) receives the id of
+// the solid's SHAPE_REPRESENTATION — the mapped-instance emitter needs it as the CDSR child rep.
 inline long emit_solid_step(adacpp::step_emit::StepBrepEmitter &em, std::string &buf,
-                            const adacpp::ngeom::NgeomRoot &root, long sid) {
+                            const adacpp::ngeom::NgeomRoot &root, long sid, long *rep_out = nullptr) {
     std::string nm = root.id.empty() ? ("solid_" + std::to_string(sid)) : adacpp::ifc_emit::ifc_str(root.id);
     long solid = 0;
     const char *rep_kw = "ADVANCED_BREP_SHAPE_REPRESENTATION";
@@ -339,12 +341,114 @@ inline long emit_solid_step(adacpp::step_emit::StepBrepEmitter &em, std::string 
     if (!solid)
         return 0;
     long rep = em.emit_entity(buf, std::string(rep_kw) + "('" + nm + "',(#13,#" + std::to_string(solid) + "),#9)");
+    if (rep_out)
+        *rep_out = rep;
     long product = em.emit_entity(buf, "PRODUCT('" + nm + "','" + nm + "','',(#3))");
     long pdf = em.emit_entity(buf, "PRODUCT_DEFINITION_FORMATION('','',#" + std::to_string(product) + ")");
     long pd = em.emit_entity(buf, "PRODUCT_DEFINITION('design','',#" + std::to_string(pdf) + ",#4)");
     long pds = em.emit_entity(buf, "PRODUCT_DEFINITION_SHAPE('','',#" + std::to_string(pd) + ")");
     em.emit_entity(buf, "SHAPE_DEFINITION_REPRESENTATION(#" + std::to_string(pds) + ",#" + std::to_string(rep) + ")");
     return pd;
+}
+
+// ---------------------------------------------------------------------------------------------
+// AP242 mapped (shared-prototype) instancing for the STEP->STEP writer.
+//
+// When a solid is placed N>1 times, the baked form serialises its full B-rep N times — on the Munin
+// crane (20,979 instances over 7,291 unique solids) that is 689k faces / ~1.7 GB where the IFC
+// writer's IfcMappedItem form needs only 300k / ~0.7 GB. The STEP counterpart chosen here is the
+// standard AP242 assembly-instancing pattern (NOT REPRESENTATION_MAP/MAPPED_ITEM), because it is
+// the exact pattern BOTH downstream native readers already parse (adapy stream_reader.py
+// _build_transform_map and the C++ Resolver::build_transform_map — validated against OCC to 1e-9):
+//
+//   prototype geometry  ->  ADVANCED_BREP_SHAPE_REPRESENTATION  (child rep, emitted ONCE, local frame)
+//   per placement k:        AXIS2_PLACEMENT_3D A_k (the world transform)
+//                           ITEM_DEFINED_TRANSFORMATION('','',#13, A_k)     (#13 = identity axis,
+//                               an item of the child rep, so T_edge = inv(I) * M(A_k) = world)
+//                           ( REPRESENTATION_RELATIONSHIP('','',child_rep, WORLD_REP)
+//                             REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(IDT)
+//                             SHAPE_REPRESENTATION_RELATIONSHIP() )
+//                           NEXT_ASSEMBLY_USAGE_OCCURRENCE(ROOT_PD, leaf_pd)
+//                           PRODUCT_DEFINITION_SHAPE('','',NAUO)
+//                           CONTEXT_DEPENDENT_SHAPE_REPRESENTATION(rr_complex, pds_nauo)
+//
+// The readers hang edges directly off the geometry rep when no standalone SRR exists (the
+// "box_comp-style" fallback), so no placement SHAPE_REPRESENTATION per prototype is needed. The
+// shared parent ("world") rep + root product block is emitted once by the caller; A_k axes must be
+// listed among its items for schema validity (OCC and the native readers all accept the file, and
+// third-party consumers expect ITEM_DEFINED_TRANSFORMATION items to belong to the related reps).
+// ---------------------------------------------------------------------------------------------
+
+// Rigidity gate for a per-instance world transform (column-major glTF float[16]): AXIS2_PLACEMENT_3D
+// can only carry a proper rigid motion (orthonormal, det=+1). Scaled / sheared / mirrored instances
+// must stay on the baked path.
+inline bool instance_tf_rigid(const std::array<float, 16> &M) {
+    const double x[3] = {M[0], M[1], M[2]}, y[3] = {M[4], M[5], M[6]}, z[3] = {M[8], M[9], M[10]};
+    auto dot = [](const double *a, const double *b) { return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]; };
+    const double tol = 1e-4;
+    if (std::abs(dot(x, x) - 1.0) > tol || std::abs(dot(y, y) - 1.0) > tol || std::abs(dot(z, z) - 1.0) > tol)
+        return false;
+    if (std::abs(dot(x, y)) > tol || std::abs(dot(y, z)) > tol || std::abs(dot(x, z)) > tol)
+        return false;
+    const double c[3] = {x[1] * y[2] - x[2] * y[1], x[2] * y[0] - x[0] * y[2], x[0] * y[1] - x[1] * y[0]};
+    return dot(c, z) > 0.0; // right-handed (det=+1); AXIS2's y is always z cross x
+}
+
+// True when `root` should be written as ONE shared prototype + per-placement references. Restricted
+// to multi-instance B-REP solids with all-rigid placements: analytic solids (extrusion/revolve/...)
+// are emitted under a plain SHAPE_REPRESENTATION, which adapy's pure-Python stream reader does not
+// classify as a geometry rep (its scanner only maps ADVANCED_BREP_SHAPE_REPRESENTATION items to
+// solids) — those keep the cheap per-instance baked form so no reader loses instances.
+inline bool step_mapped_eligible(const adacpp::ngeom::NgeomRoot &root) {
+    if (root.extrusion || root.revolve || root.sweep || root.sphere || root.boolean)
+        return false;
+    if (root.faces.empty() || root.transforms.size() < 2)
+        return false;
+    for (const auto &T : root.transforms)
+        if (!instance_tf_rigid(T))
+            return false;
+    return true;
+}
+
+// Escape hatch: force the pre-instancing behaviour (every placement fully baked).
+inline bool step_bake_instances_forced() {
+    const char *e = std::getenv("ADACPP_STEP_BAKE_INSTANCES");
+    return e && *e && *e != '0';
+}
+
+// Emit the per-placement reference records for a prototype already written by emit_solid_step
+// (identity transform): one AXIS2 + IDT + complex-RR + NAUO + PDS + CDSR per world transform.
+// `rep_id`/`leaf_pd` are the prototype's rep and PRODUCT_DEFINITION; `root_pd_id`/`world_rep_id`/
+// `identity_axis_id` are the caller's shared assembly-root PD, world rep and identity AXIS2 (#13).
+// `sid` seeds unique NAUO occurrence ids. Each instance's AXIS2 id is appended to `axis_ids_out` so
+// the caller can list them among the world rep's items.
+inline void emit_step_mapped_instances(adacpp::step_emit::StepBrepEmitter &em, std::string &buf, long rep_id,
+                                       long leaf_pd, const std::string &nm, long sid,
+                                       const std::vector<std::array<float, 16>> &transforms, long root_pd_id,
+                                       long world_rep_id, long identity_axis_id, std::vector<long> &axis_ids_out) {
+    using adacpp::ifc_emit::ifc_real;
+    auto R = [](float v) { return ifc_real(v); };
+    auto ref = [](long id) { return "#" + std::to_string(id); };
+    int k = 0;
+    for (const auto &T : transforms) {
+        long loc = em.emit_entity(buf, "CARTESIAN_POINT('',(" + R(T[12]) + "," + R(T[13]) + "," + R(T[14]) + "))");
+        long az = em.emit_entity(buf, "DIRECTION('',(" + R(T[8]) + "," + R(T[9]) + "," + R(T[10]) + "))");
+        long ax = em.emit_entity(buf, "DIRECTION('',(" + R(T[0]) + "," + R(T[1]) + "," + R(T[2]) + "))");
+        long axis =
+            em.emit_entity(buf, "AXIS2_PLACEMENT_3D(''," + ref(loc) + "," + ref(az) + "," + ref(ax) + ")");
+        long idt = em.emit_entity(
+            buf, "ITEM_DEFINED_TRANSFORMATION('',''," + ref(identity_axis_id) + "," + ref(axis) + ")");
+        long rr = em.emit_entity(buf, "(REPRESENTATION_RELATIONSHIP('',''," + ref(rep_id) + "," + ref(world_rep_id) +
+                                          ")REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(" + ref(idt) +
+                                          ")SHAPE_REPRESENTATION_RELATIONSHIP())");
+        std::string occ = "i" + std::to_string(sid) + "_" + std::to_string(k);
+        long nauo = em.emit_entity(buf, "NEXT_ASSEMBLY_USAGE_OCCURRENCE('" + occ + "','" + nm + "',''," +
+                                            ref(root_pd_id) + "," + ref(leaf_pd) + ",$)");
+        long pds = em.emit_entity(buf, "PRODUCT_DEFINITION_SHAPE('',''," + ref(nauo) + ")");
+        em.emit_entity(buf, "CONTEXT_DEPENDENT_SHAPE_REPRESENTATION(" + ref(rr) + "," + ref(pds) + ")");
+        axis_ids_out.push_back(axis);
+        ++k;
+    }
 }
 
 // Emit a NEXT_ASSEMBLY_USAGE_OCCURRENCE assembly tree from per-leaf (product_definition, path): each

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -3983,6 +3983,7 @@ static adacpp::ifc_emit::FileStats stream_ngeom_to_step_impl(nb::iterable record
     };
     const bool bake_forced = step_bake_instances_forced();
     std::vector<long> leaf_pds;       // baked leaves (mapped leaves hang under ROOT_PD instead)
+    std::vector<long> leaf_reps;      // parallel: each leaf's SHAPE_REPRESENTATION (CDSR child rep)
     std::vector<IfcPath2> leaf_paths; // parallel: each baked leaf's assembly path
     std::vector<long> styled;         // STYLED_ITEM ids for the presentation trailer
     std::vector<long> world_axes;     // mapped-instance AXIS2 ids -> the world rep's items
@@ -4034,8 +4035,8 @@ static adacpp::ifc_emit::FileStats stream_ngeom_to_step_impl(nb::iterable record
                         tfp = tf;
                     }
                     StepBrepEmitter em(nid, tfp, deflection, angular_deg);
-                    long solid_id = 0;
-                    long pd = emit_solid_step(em, buf, root, sid, nullptr, &solid_id);
+                    long solid_id = 0, rep_id = 0;
+                    long pd = emit_solid_step(em, buf, root, sid, &rep_id, &solid_id);
                     if (pd) {
                         if (root.has_color && solid_id)
                             styled.push_back(emit_step_color(em, buf, solid_id, root.cr, root.cg, root.cb));
@@ -4043,6 +4044,7 @@ static adacpp::ifc_emit::FileStats stream_ngeom_to_step_impl(nb::iterable record
                         any = true;
                         ++fs.instances_out;
                         leaf_pds.push_back(pd);
+                        leaf_reps.push_back(rep_id);
                         leaf_paths.push_back(k < root.instance_paths.size() ? root.instance_paths[k] : IfcPath2{});
                         accum_geom(fs.geom, em.stats());
                     }
@@ -4057,7 +4059,7 @@ static adacpp::ifc_emit::FileStats stream_ngeom_to_step_impl(nb::iterable record
     }
     fs.products_total = fs.solids_in;
     StepBrepEmitter emtail(nid, nullptr, deflection, angular_deg);
-    emit_step_assembly_tree(emtail, buf, leaf_pds, leaf_paths);
+    emit_step_assembly_tree(emtail, buf, leaf_pds, leaf_reps, leaf_paths);
     if (!world_axes.empty()) {
         buf += "#14=PRODUCT('model','model','',(#3));\n";
         buf += "#15=PRODUCT_DEFINITION_FORMATION('','',#14);\n";

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -3891,6 +3891,268 @@ static void step_parity_impl(const std::string &in_path, double deflection, doub
     total_instances_out = total_instances.load();
 }
 
+// ---------------------------------------------------------------------------------------------
+// NGEOM-blob record streams -> STEP / IFC files (the ada-object-model export fast path).
+//
+// The Python side walks an assembly, serializes each object's solid_geom() to an NGEOM blob
+// (adapy serialize_geometries — the same vocabulary tessellate_stream decodes), and hands the
+// records to these writers one at a time. Records are consumed LAZILY from any Python iterable
+// (list or generator), and each record is decoded + emitted + released before the next is pulled,
+// so a 100k-solid model streams at bounded memory. This replaces the ~ms/face per-entity Python
+// writers (ifcopenshell / ap242_stream) with the ~µs/face C++ emitters for models whose objects
+// all serialize to NGEOM.
+//
+// Record shape (a tuple/sequence; trailing elements optional):
+//   (name, blob [, color_rgba [, transforms [, paths]]])
+//     name        str|None — product name; non-empty overrides the blob's root id
+//     blob        bytes    — one NGEOM buffer (usually one root; all roots are emitted)
+//     color_rgba  4 floats — presentation colour; alpha < 0 (or None) = no colour
+//     transforms  list of 16-float column-major (glTF) world placements; None/[] = one identity
+//     paths       per-instance assembly path: list of [(rep_id, name), ...] levels, parallel to
+//                 transforms (one entry total when transforms is empty)
+struct NgeomEmitRecord {
+    std::string name;
+    nb::bytes blob;
+    std::array<float, 4> color{0.f, 0.f, 0.f, -1.f}; // alpha<0 sentinel => no colour
+    std::vector<std::array<float, 16>> transforms;
+    std::vector<std::vector<std::pair<int, std::string>>> paths;
+};
+
+static NgeomEmitRecord parse_ngeom_record(nb::handle item) {
+    NgeomEmitRecord rec;
+    nb::sequence seq = nb::cast<nb::sequence>(item);
+    size_t n = nb::len(seq);
+    if (n < 2)
+        throw std::runtime_error("NGEOM record needs at least (name, blob)");
+    if (!seq[0].is_none())
+        rec.name = nb::cast<std::string>(seq[0]);
+    rec.blob = nb::cast<nb::bytes>(seq[1]);
+    if (n > 2 && !seq[2].is_none())
+        rec.color = nb::cast<std::array<float, 4>>(seq[2]);
+    if (n > 3 && !seq[3].is_none())
+        rec.transforms = nb::cast<std::vector<std::array<float, 16>>>(seq[3]);
+    if (n > 4 && !seq[4].is_none())
+        rec.paths = nb::cast<std::vector<std::vector<std::pair<int, std::string>>>>(seq[4]);
+    return rec;
+}
+
+// Attach a record's out-of-band metadata to a decoded root (the blob carries geometry + id only).
+static void apply_record_meta(adacpp::ngeom::NgeomRoot &root, const NgeomEmitRecord &rec) {
+    if (!rec.name.empty())
+        root.id = rec.name;
+    if (rec.color[3] >= 0.0f) {
+        root.has_color = true;
+        root.cr = rec.color[0];
+        root.cg = rec.color[1];
+        root.cb = rec.color[2];
+        root.ca = rec.color[3];
+    }
+    root.transforms = rec.transforms;
+    root.instance_paths = rec.paths;
+}
+
+// NGEOM records -> AP242 STEP file. Serial (one running id, no renumber pass): decode each blob,
+// emit each root via emit_solid_step — mapped-eligible multi-instance solids as ONE shared
+// prototype + per-placement NAUO/CDSR references (write_step_file_impl's pattern), everything else
+// baked per instance — then the NAUO assembly tree from the record paths, the mapped-instance root
+// block (SPF statement order is irrelevant, so it can trail its references), and the colour trailer.
+static adacpp::ifc_emit::FileStats stream_ngeom_to_step_impl(nb::iterable records, const std::string &out_path,
+                                                             double unit_scale, double deflection, double angular_deg) {
+    using adacpp::ngeom::NgeomRoot;
+    using adacpp::step_emit::StepBrepEmitter;
+    adacpp::ifc_emit::FileStats fs;
+    fs.unit_scale = unit_scale;
+    std::FILE *fp = std::fopen(out_path.c_str(), "wb");
+    if (!fp)
+        return fs;
+    std::string hdr = step_header_block(unit_scale);
+    std::fwrite(hdr.data(), 1, hdr.size(), fp);
+    // Reserve the mapped-instance shared-root ids up front (#14..#17 root PRODUCT chain, #18 world
+    // rep — written at the end, only if some solid actually took the mapped path; unused reserved
+    // ids are legal SPF gaps and keep this writer renumber-free).
+    const long K = 18;
+    const long ROOT_PD = 16, WORLD_REP = 18, IDENTITY_AXIS = 13;
+    long nid = K;
+    std::string buf;
+    buf.reserve(1 << 22);
+    auto flush = [&](bool force) {
+        if (buf.size() >= (4u << 20) || force) {
+            std::fwrite(buf.data(), 1, buf.size(), fp);
+            buf.clear();
+        }
+    };
+    const bool bake_forced = step_bake_instances_forced();
+    std::vector<long> leaf_pds;       // baked leaves (mapped leaves hang under ROOT_PD instead)
+    std::vector<IfcPath2> leaf_paths; // parallel: each baked leaf's assembly path
+    std::vector<long> styled;         // STYLED_ITEM ids for the presentation trailer
+    std::vector<long> world_axes;     // mapped-instance AXIS2 ids -> the world rep's items
+    long sid = 0;
+    for (nb::handle item : records) {
+        NgeomEmitRecord rec = parse_ngeom_record(item);
+        adacpp::ngeom::NgeomDoc doc =
+            adacpp::ngeom::decode(reinterpret_cast<const uint8_t *>(rec.blob.c_str()), rec.blob.size());
+        for (NgeomRoot &root : doc.roots) {
+            ++sid;
+            ++fs.solids_in;
+            apply_record_meta(root, rec);
+            std::string nm = root.id.empty() ? ("solid_" + std::to_string(sid)) : adacpp::ifc_emit::ifc_str(root.id);
+            bool any = false;
+            if (!bake_forced && step_mapped_eligible(root)) {
+                StepBrepEmitter em(nid, nullptr, deflection, angular_deg);
+                long rep_id = 0, solid_id = 0;
+                long pd = emit_solid_step(em, buf, root, sid, &rep_id, &solid_id);
+                if (pd) {
+                    emit_step_mapped_instances(em, buf, rep_id, pd, nm, sid, root.transforms, ROOT_PD, WORLD_REP,
+                                               IDENTITY_AXIS, world_axes);
+                    if (root.has_color && solid_id)
+                        styled.push_back(emit_step_color(em, buf, solid_id, root.cr, root.cg, root.cb));
+                    nid = em.current_id();
+                    any = true;
+                    fs.instances_out += (long) root.transforms.size();
+                    accum_geom(fs.geom, em.stats());
+                }
+            } else {
+                size_t ninst = root.transforms.empty() ? 1 : root.transforms.size();
+                for (size_t k = 0; k < ninst; ++k) {
+                    double tf[16];
+                    const double *tfp = nullptr;
+                    if (!root.transforms.empty()) {
+                        // ng:: transforms are column-major glTF; StepBrepEmitter wants row-major.
+                        const std::array<float, 16> &M = root.transforms[k];
+                        tf[0] = M[0];
+                        tf[1] = M[4];
+                        tf[2] = M[8];
+                        tf[3] = M[12];
+                        tf[4] = M[1];
+                        tf[5] = M[5];
+                        tf[6] = M[9];
+                        tf[7] = M[13];
+                        tf[8] = M[2];
+                        tf[9] = M[6];
+                        tf[10] = M[10];
+                        tf[11] = M[14];
+                        tfp = tf;
+                    }
+                    StepBrepEmitter em(nid, tfp, deflection, angular_deg);
+                    long solid_id = 0;
+                    long pd = emit_solid_step(em, buf, root, sid, nullptr, &solid_id);
+                    if (pd) {
+                        if (root.has_color && solid_id)
+                            styled.push_back(emit_step_color(em, buf, solid_id, root.cr, root.cg, root.cb));
+                        nid = em.current_id();
+                        any = true;
+                        ++fs.instances_out;
+                        leaf_pds.push_back(pd);
+                        leaf_paths.push_back(k < root.instance_paths.size() ? root.instance_paths[k] : IfcPath2{});
+                        accum_geom(fs.geom, em.stats());
+                    }
+                }
+            }
+            if (any)
+                ++fs.solids_out;
+            else
+                ++fs.products_skipped;
+            flush(false);
+        }
+    }
+    fs.products_total = fs.solids_in;
+    StepBrepEmitter emtail(nid, nullptr, deflection, angular_deg);
+    emit_step_assembly_tree(emtail, buf, leaf_pds, leaf_paths);
+    if (!world_axes.empty()) {
+        buf += "#14=PRODUCT('model','model','',(#3));\n";
+        buf += "#15=PRODUCT_DEFINITION_FORMATION('','',#14);\n";
+        buf += "#16=PRODUCT_DEFINITION('design','',#15,#4);\n";
+        buf += "#17=PRODUCT_DEFINITION_SHAPE('','',#16);\n";
+        buf += "#18=SHAPE_REPRESENTATION('model',(#13";
+        for (long a : world_axes) {
+            buf += ",#";
+            buf += std::to_string(a);
+        }
+        buf += "),#9);\n";
+        emtail.emit_entity(buf, "SHAPE_DEFINITION_REPRESENTATION(#17,#18)");
+    }
+    step_color_trailer(emtail, buf, styled);
+    buf += "ENDSEC;\nEND-ISO-10303-21;\n";
+    flush(true);
+    std::fclose(fp);
+    return fs;
+}
+
+// NGEOM records -> IFC file. The record-stream sibling of blobs_to_ifc_impl (which takes parallel
+// lists): same emit_solid_ifc + IfcStyledItem + spatial tree, but records are pulled lazily so a
+// generator streams at bounded memory.
+static adacpp::ifc_emit::FileStats stream_ngeom_to_ifc_impl(nb::iterable records, const std::string &out_path,
+                                                            const std::string &schema, double unit_scale,
+                                                            double deflection, double angular_deg) {
+    using namespace adacpp::ifc_emit;
+    using adacpp::ngeom::NgeomRoot;
+    FileStats fs;
+    fs.unit_scale = unit_scale;
+    std::FILE *fp = std::fopen(out_path.c_str(), "wb");
+    if (!fp)
+        return fs;
+    std::string buf;
+    buf.reserve(1 << 22);
+    auto flush = [&](bool force) {
+        if (buf.size() >= (4u << 20) || force) {
+            std::fwrite(buf.data(), 1, buf.size(), fp);
+            buf.clear();
+        }
+    };
+    buf += ifc_header_block(schema, unit_scale);
+    BrepEmitter em(100, nullptr, deflection, angular_deg);
+    std::vector<long> proxies;
+    std::vector<IfcPath> proxy_paths;
+    long sid = 0;
+    for (nb::handle item : records) {
+        NgeomEmitRecord rec = parse_ngeom_record(item);
+        adacpp::ngeom::NgeomDoc doc =
+            adacpp::ngeom::decode(reinterpret_cast<const uint8_t *>(rec.blob.c_str()), rec.blob.size());
+        for (NgeomRoot &root : doc.roots) {
+            ++sid;
+            ++fs.solids_in;
+            apply_record_meta(root, rec);
+            size_t before = proxies.size();
+            // guid seed strided by 1000 per solid (instances use seed+k) — matches blobs_to_ifc.
+            emit_solid_ifc(em, buf, root, sid, (uint64_t) sid * 1000u, proxies, &proxy_paths);
+            if (proxies.size() > before)
+                ++fs.solids_out;
+            else
+                ++fs.products_skipped;
+            fs.instances_out += (long) (proxies.size() - before);
+            flush(false);
+        }
+    }
+    fs.products_total = fs.solids_in;
+    emit_spatial_tree(buf, [&]() { return em.alloc_id(); }, proxies, proxy_paths);
+    buf += "ENDSEC;\nEND-ISO-10303-21;\n";
+    flush(true);
+    std::fclose(fp);
+    fs.geom = em.stats();
+    return fs;
+}
+
+// The shared stats dict for the two NGEOM-record writers (mirrors stream_step_to_step's audit).
+static nb::dict ngeom_emit_stats_dict(const adacpp::ifc_emit::FileStats &fs) {
+    nb::dict d;
+    d["solids_in"] = fs.solids_in;
+    d["solids_out"] = fs.solids_out;
+    d["instances_out"] = fs.instances_out;
+    d["solids_skipped"] = fs.products_skipped;
+    d["unit_scale"] = fs.unit_scale;
+    d["faces_in"] = fs.geom.faces_in;
+    d["faces_out"] = fs.geom.faces_out;
+    d["faces_dropped"] = fs.geom.faces_dropped;
+    d["edges_analytic"] = fs.geom.edges_analytic;
+    d["edges_polyline_approx"] = fs.geom.edges_polyline_approx;
+    d["edges_degenerate"] = fs.geom.edges_degenerate;
+    nb::dict reasons;
+    for (const auto &[k, v] : fs.geom.drop_reasons)
+        reasons[k.c_str()] = v;
+    d["drop_reasons"] = reasons;
+    return d;
+}
+
 void cad_module(nb::module_ &m) {
     // Kernel-agnostic mesh / color / group types live in cad — they're the
     // surface every backend (native OCCT, wasm OCCT, future CGAL) speaks.
@@ -4153,6 +4415,46 @@ void cad_module(nb::module_ &m) {
         "colors (rgba; alpha<0 => none), transforms (per-shape 4x4 world placements), paths (per-shape "
         "instance_paths). Decodes each blob, re-attaches the metadata, and emits IfcAdvancedBrep + "
         "IfcStyledItem + spatial tree — the fully-native Assembly.to_ifc backend. Returns the audit dict.");
+
+    // NGEOM record streams -> STEP / IFC: the ada-object-model export fast path (Genie-XML ->
+    // step/ifc without the per-entity Python writers). Records are consumed lazily from any Python
+    // iterable, one blob decoded + emitted + released at a time (bounded memory).
+    m.def(
+        "stream_ngeom_to_step",
+        [](nb::iterable records, const std::string &out_path, double unit_scale, double deflection,
+           double angular_deg) -> nb::dict {
+            return ngeom_emit_stats_dict(
+                stream_ngeom_to_step_impl(records, out_path, unit_scale, deflection, angular_deg));
+        },
+        "records"_a, "out_path"_a, "unit_scale"_a = 1.0, "deflection"_a = 2.0, "angular_deg"_a = 20.0,
+        "Native AP242 STEP writer from a stream of NGEOM records. Each record is a sequence "
+        "(name, blob[, color_rgba[, transforms[, paths]]]): name (str|None) overrides the blob's root "
+        "id; blob is one NGEOM buffer (adapy serialize_geometries); color_rgba is 4 floats (alpha<0 or "
+        "None => no colour, else a STYLED_ITEM presentation colour); transforms is a list of 16-float "
+        "column-major world placements (None/[] => one identity instance); paths is the per-instance "
+        "assembly path ([(rep_id, name), ...] levels) emitted as a NEXT_ASSEMBLY_USAGE_OCCURRENCE "
+        "tree. Multi-instance B-rep solids with rigid placements are written once as a shared "
+        "prototype + per-placement NAUO/CDSR references (ADACPP_STEP_BAKE_INSTANCES=1 forces the "
+        "all-baked form); everything else is baked per instance. Records may come from a generator — "
+        "they are pulled lazily, so a 100k-solid model streams at bounded memory. unit_scale = metres "
+        "per model unit (sets the header SI length unit). Returns the losslessness audit dict "
+        "(solids_in/out, instances_out, solids_skipped, faces_in/out/dropped, drop_reasons).");
+
+    m.def(
+        "stream_ngeom_to_ifc",
+        [](nb::iterable records, const std::string &out_path, const std::string &schema, double unit_scale,
+           double deflection, double angular_deg) -> nb::dict {
+            return ngeom_emit_stats_dict(
+                stream_ngeom_to_ifc_impl(records, out_path, schema, unit_scale, deflection, angular_deg));
+        },
+        "records"_a, "out_path"_a, "schema"_a = "IFC4X3_ADD2", "unit_scale"_a = 1.0, "deflection"_a = 2.0,
+        "angular_deg"_a = 20.0,
+        "Native IFC writer from a stream of NGEOM records — the record-stream sibling of blobs_to_ifc "
+        "(same record shape as stream_ngeom_to_step). Decodes each blob and emits the analytic IFC "
+        "solid (IfcAdvancedBrep / IfcExtrudedAreaSolid / ...) + IfcStyledItem colour + the "
+        "IfcSpatialZone tree from the record paths; multi-instance solids share geometry via "
+        "IfcMappedItem. Records are pulled lazily (generator-friendly, bounded memory). schema: "
+        "'IFC4X3_ADD2' | 'IFC4'. Returns the losslessness audit dict.");
 
     // Native parallel STEP->STEP (AP242). Re-export the analytic B-rep per solid, instances baked,
     // round-trip-lossless. Returns the same losslessness audit dict.

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -4134,6 +4134,43 @@ static adacpp::ifc_emit::FileStats stream_ngeom_to_ifc_impl(nb::iterable records
     return fs;
 }
 
+// One NGEOM blob -> the SPF text of its IFC geometry-body entity graph ONLY (the IfcAdvancedBrep /
+// analytic-solid faces/edges/surfaces lines), numbered from `first_id`. No header/footer, no product
+// or spatial entities, no styling — the caller (adapy's streaming IFC writer) splices the fragment
+// into its own file and hand-authors the TYPED wrapper (IfcShapeRepresentation -> IfcPlate/...)
+// around the returned body item id. This is what lets typed, round-trippable products keep the
+// ~µs/face C++ geometry emit (stream_ngeom_to_ifc's proxy wrapper made every product an
+// IfcBuildingElementProxy). The body-graph emitter is ifc_emit::BrepEmitter::emit_solid — the same
+// machinery emit_solid_ifc wraps — so fragment output is byte-identical to the file writers' bodies.
+//
+// Returns (spf_text, next_id, body_item_id, rep_type):
+//   spf_text     the entity lines, ids first_id..next_id-1 (children before parents)
+//   next_id      the next free entity id (pass to a subsequent call to keep numbering contiguous)
+//   body_item_id id of the top representation item (the IfcAdvancedBrep / IfcExtrudedAreaSolid / ...),
+//                or 0 when the root is unrepresentable OR any face dropped — the caller must then
+//                DISCARD spf_text and take its Python fallback (partial geometry is never a success:
+//                "no geometry left behind")
+//   rep_type     the matching IfcShapeRepresentation.RepresentationType ("AdvancedBrep" /
+//                "SweptSolid" / "CSG" / "AdvancedSweptSolid"); "" when body_item_id is 0
+// The blob must hold exactly one root (adapy serializes one solid_geom() per object); anything else
+// raises. The geometry-body entities are schema-invariant across IFC4/IFC4X3, so no schema parameter.
+static nb::tuple ngeom_to_ifc_body_spf_impl(nb::bytes blob, long first_id, double deflection, double angular_deg) {
+    adacpp::ngeom::NgeomDoc doc = adacpp::ngeom::decode(reinterpret_cast<const uint8_t *>(blob.c_str()), blob.size());
+    if (doc.roots.size() != 1)
+        throw std::runtime_error("ngeom_to_ifc_body_spf: blob must hold exactly one root, got " +
+                                 std::to_string(doc.roots.size()));
+    // BrepEmitter::emit pre-increments, so seed at first_id-1 to number entities from first_id.
+    adacpp::ifc_emit::BrepEmitter em(first_id - 1, nullptr, deflection, angular_deg);
+    std::string buf, rep_type;
+    long body = em.emit_solid(buf, doc.roots[0], rep_type);
+    if (body && em.stats().faces_dropped > 0)
+        body = 0; // strict: a partially-emitted shell is a failure, not a smaller success
+    if (!body)
+        return nb::make_tuple(nb::str(""), first_id, (long) 0, nb::str(""));
+    return nb::make_tuple(nb::str(buf.c_str(), buf.size()), em.current_id() + 1, body,
+                          nb::str(rep_type.c_str(), rep_type.size()));
+}
+
 // The shared stats dict for the two NGEOM-record writers (mirrors stream_step_to_step's audit).
 static nb::dict ngeom_emit_stats_dict(const adacpp::ifc_emit::FileStats &fs) {
     nb::dict d;
@@ -4457,6 +4494,22 @@ void cad_module(nb::module_ &m) {
         "IfcSpatialZone tree from the record paths; multi-instance solids share geometry via "
         "IfcMappedItem. Records are pulled lazily (generator-friendly, bounded memory). schema: "
         "'IFC4X3_ADD2' | 'IFC4'. Returns the losslessness audit dict.");
+
+    m.def(
+        "ngeom_to_ifc_body_spf",
+        [](nb::bytes blob, long first_id, double deflection, double angular_deg) -> nb::tuple {
+            return ngeom_to_ifc_body_spf_impl(blob, first_id, deflection, angular_deg);
+        },
+        "blob"_a, "first_id"_a, "deflection"_a = 2.0, "angular_deg"_a = 20.0,
+        "Emit ONE NGEOM blob's IFC geometry-body entity graph as an SPF text fragment (no "
+        "header/product/spatial entities), numbering entities from first_id. Returns (spf_text, "
+        "next_id, body_item_id, rep_type) where body_item_id is the top representation item (the "
+        "IfcAdvancedBrep / analytic solid) and rep_type the matching "
+        "IfcShapeRepresentation.RepresentationType. body_item_id == 0 (unrepresentable root or any "
+        "dropped face) means: discard spf_text and fall back — a partial body is never returned. "
+        "The blob must hold exactly one root. The fragment is schema-invariant (IFC4 / IFC4X3). "
+        "Used by adapy's streaming IFC writer to keep TYPED products (IfcPlate/IfcBeam wrappers "
+        "hand-authored in Python) while the heavy B-rep body graph is emitted at C++ speed.");
 
     // Native parallel STEP->STEP (AP242). Re-export the analytic B-rep per solid, instances baked,
     // round-trip-lossless. Returns the same losslessness audit dict.

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -39,12 +39,14 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <map>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <deque>
+#include <mutex>
 #include <tuple>
 #include <cstdlib>
 #include <filesystem>
@@ -3937,7 +3939,9 @@ static NgeomEmitRecord parse_ngeom_record(nb::handle item) {
 }
 
 // Attach a record's out-of-band metadata to a decoded root (the blob carries geometry + id only).
-static void apply_record_meta(adacpp::ngeom::NgeomRoot &root, const NgeomEmitRecord &rec) {
+// Template so both record forms share it: NgeomEmitRecord (Python-owned blob, the serial STEP/IFC
+// emitters) and NgeomTessRecord (GIL-free copy, the threaded GLB/mesh tessellation path below).
+template <class Rec> static void apply_record_meta(adacpp::ngeom::NgeomRoot &root, const Rec &rec) {
     if (!rec.name.empty())
         root.id = rec.name;
     if (rec.color[3] >= 0.0f) {
@@ -4132,6 +4136,388 @@ static adacpp::ifc_emit::FileStats stream_ngeom_to_ifc_impl(nb::iterable records
     std::fclose(fp);
     fs.geom = em.stats();
     return fs;
+}
+
+// ---------------------------------------------------------------------------------------------
+// NGEOM-record streams -> GLB / OBJ / STL (the ada-object-model MESH export fast path).
+//
+// The same record front-end as stream_ngeom_to_step/ifc — (name, blob[, color[, transforms[,
+// paths]]]) records pulled lazily from any Python iterable — feeding the back half of the native
+// STEP->GLB / STEP->mesh cores: the libtess2/cdt tessellation tracks, world-transform + unit
+// baking, the merge-by-colour GLB writer with inline EXT_meshopt, and the welded-OBJ / binary-STL
+// lane writers. This replaces adapy's Python tessellation-scene assembly + trimesh writers for
+// ada-object sources (Genie XML): the hull's 137 s xml->obj becomes the same class as the native
+// step->obj leg.
+//
+// Parallel but DETERMINISTIC: the calling thread parses records (it holds the GIL) into a bounded
+// task queue; `num_threads` pure-C++ workers decode + tessellate; each finished record is
+// committed strictly in record order into ONE writer lane (a commit turnstile — the worker owning
+// the next sequence number commits, others wait). Output bytes therefore depend only on the
+// records and the tessellation knobs — never on scheduling or thread count — and a generator
+// input is byte-identical to a list input. Backpressure is structural: at most `qcap` parsed
+// records + one finished mesh per worker are in flight.
+
+struct NgeomTessRecord { // GIL-free copy of one parsed record (workers never touch Python)
+    std::string name;
+    std::string blob;
+    std::array<float, 4> color{0.f, 0.f, 0.f, -1.f};
+    std::vector<std::array<float, 16>> transforms;
+    std::vector<std::vector<std::pair<int, std::string>>> paths;
+};
+
+static NgeomTessRecord own_ngeom_record(nb::handle item) {
+    NgeomEmitRecord r = parse_ngeom_record(item);
+    NgeomTessRecord rec;
+    rec.name = std::move(r.name);
+    rec.blob.assign(r.blob.c_str(), r.blob.size());
+    rec.color = r.color;
+    rec.transforms = std::move(r.transforms);
+    rec.paths = std::move(r.paths);
+    return rec;
+}
+
+struct NgeomTessStats {
+    long solids_in = 0, solids_out = 0, solids_skipped = 0, instances_out = 0;
+    unsigned long long triangles = 0; // world triangles (per-solid tris x instances)
+};
+
+// Decode + tessellate one record into commit-ready GlbSolids: metadata attached, positions and
+// instance translations pre-scaled to metres, per-face colours split into per-colour parts when
+// requested (`split_by_face_colour`, the GLB material path; picking face ranges stay off). Pure
+// C++ — runs on any thread.
+static void ngeom_tess_process(const NgeomTessRecord &rec, const adacpp::ngeom::TessParams &tp, double unit_scale,
+                               bool split_by_face_colour, std::vector<adacpp::glb::GlbSolid> &parts,
+                               NgeomTessStats &st) {
+    using adacpp::glb::GlbSolid;
+    using adacpp::ngeom::NgeomDoc;
+    using adacpp::ngeom::NgeomRoot;
+    using adacpp::ngeom::TessMesh;
+    NgeomDoc doc = adacpp::ngeom::decode(reinterpret_cast<const uint8_t *>(rec.blob.data()), rec.blob.size());
+    for (NgeomRoot &root : doc.roots) {
+        ++st.solids_in;
+        apply_record_meta(root, rec);
+        NgeomDoc one;
+        one.roots.push_back(std::move(root));
+        TessMesh tm = tessellate_doc(one, tp);
+        if (tm.indices.empty()) {
+            ++st.solids_skipped;
+            continue;
+        }
+        const NgeomRoot &rr = one.roots[0];
+        GlbSolid gs;
+        gs.positions = std::move(tm.positions);
+        gs.indices = std::move(tm.indices);
+        gs.face_ranges.reserve(tm.face_ranges.size());
+        for (const auto &fr : tm.face_ranges)
+            gs.face_ranges.push_back({fr.first_index, fr.index_count, fr.face_id, fr.face_seq, fr.has_color, fr.cr,
+                                      fr.cg, fr.cb, fr.ca});
+        gs.color = {rr.cr, rr.cg, rr.cb, rr.ca}; // grey default when !has_color
+        gs.transforms = rr.transforms;
+        gs.id = rr.id.empty() ? rec.name : rr.id;
+        if (!rr.instance_paths.empty() && !rr.instance_paths[0].empty())
+            gs.product_name = rr.instance_paths[0].back().second;
+        gs.instance_paths = rr.instance_paths;
+        if (unit_scale != 1.0) { // model units -> metres (positions + instance translations)
+            const float s = (float) unit_scale;
+            for (float &p : gs.positions)
+                p *= s;
+            for (auto &M : gs.transforms) {
+                M[12] *= s;
+                M[13] *= s;
+                M[14] *= s;
+            }
+        }
+        const size_t ninst = gs.transforms.empty() ? 1 : gs.transforms.size();
+        ++st.solids_out;
+        st.instances_out += (long) ninst;
+        st.triangles += (unsigned long long) (gs.indices.size() / 3) * ninst;
+        if (split_by_face_colour) {
+            for (GlbSolid &part : adacpp::glb::split_solid_by_face_colour(gs)) {
+                part.face_ranges.clear(); // colour split done; picking extras not exposed on this path
+                parts.push_back(std::move(part));
+            }
+        } else {
+            parts.push_back(std::move(gs));
+        }
+    }
+}
+
+// Pump records through `nthreads` tessellation workers, committing each record's parts in record
+// order via `commit` (invoked by exactly one thread at a time). Python is touched only on the
+// calling thread. The first worker/commit error is re-thrown after every thread has joined (the
+// remaining queue still drains so the turnstile never deadlocks).
+static NgeomTessStats
+stream_ngeom_tess_pump(nb::iterable records, const adacpp::ngeom::TessParams &tp, int nthreads, double unit_scale,
+                       bool split_by_face_colour,
+                       const std::function<void(std::vector<adacpp::glb::GlbSolid> &)> &commit) {
+    NgeomTessStats total;
+    if (nthreads <= 1) { // serial — also the no-pthreads (wasm) path
+        for (nb::handle item : records) {
+            NgeomTessRecord rec = own_ngeom_record(item);
+            std::vector<adacpp::glb::GlbSolid> parts;
+            ngeom_tess_process(rec, tp, unit_scale, split_by_face_colour, parts, total);
+            commit(parts);
+        }
+        return total;
+    }
+
+    struct Task {
+        size_t seq = 0;
+        NgeomTessRecord rec;
+    };
+    std::mutex qm; // task queue (bounded)
+    std::condition_variable q_can_push, q_can_pop;
+    std::deque<Task> queue;
+    bool input_done = false;
+    const size_t qcap = (size_t) nthreads * 2 + 2;
+
+    std::mutex cm; // commit turnstile: strictly-ordered single-writer commits
+    std::condition_variable ccv;
+    size_t next_commit = 0;
+
+    std::mutex em;
+    std::string error; // first failure (workers keep draining so the turnstile stays live)
+
+    auto worker = [&]() {
+        int local = 0;
+        for (;;) {
+            Task task;
+            {
+                std::unique_lock<std::mutex> lk(qm);
+                q_can_pop.wait(lk, [&] { return !queue.empty() || input_done; });
+                if (queue.empty())
+                    return;
+                task = std::move(queue.front());
+                queue.pop_front();
+            }
+            q_can_push.notify_one();
+            std::vector<adacpp::glb::GlbSolid> parts;
+            NgeomTessStats st;
+            try {
+                ngeom_tess_process(task.rec, tp, unit_scale, split_by_face_colour, parts, st);
+            } catch (const std::exception &ex) {
+                std::lock_guard<std::mutex> lk(em);
+                if (error.empty())
+                    error = std::string(ex.what()) + " (record '" + task.rec.name + "')";
+                parts.clear();
+            }
+            {
+                std::unique_lock<std::mutex> lk(cm);
+                ccv.wait(lk, [&] { return next_commit == task.seq; });
+                try {
+                    commit(parts);
+                } catch (const std::exception &ex) {
+                    std::lock_guard<std::mutex> elk(em);
+                    if (error.empty())
+                        error = std::string("commit: ") + ex.what();
+                }
+                total.solids_in += st.solids_in;
+                total.solids_out += st.solids_out;
+                total.solids_skipped += st.solids_skipped;
+                total.instances_out += st.instances_out;
+                total.triangles += st.triangles;
+                ++next_commit;
+            }
+            ccv.notify_all();
+            if (++local % 64 == 0)
+                adacpp::mem_trim(); // return per-record churn to the OS
+        }
+    };
+
+    std::vector<std::thread> pool;
+    pool.reserve(nthreads);
+    for (int t = 0; t < nthreads; ++t)
+        pool.emplace_back(worker);
+    auto finish = [&] {
+        {
+            std::lock_guard<std::mutex> lk(qm);
+            input_done = true;
+        }
+        q_can_pop.notify_all();
+        for (std::thread &th : pool)
+            th.join();
+    };
+    try {
+        size_t seq = 0;
+        for (nb::handle item : records) {
+            Task task;
+            task.seq = seq++;
+            task.rec = own_ngeom_record(item);
+            {
+                std::unique_lock<std::mutex> lk(qm);
+                q_can_push.wait(lk, [&] { return queue.size() < qcap; });
+                queue.push_back(std::move(task));
+            }
+            q_can_pop.notify_one();
+        }
+    } catch (...) {
+        finish(); // drain what was queued so every thread joins cleanly, then re-throw
+        throw;
+    }
+    finish();
+    {
+        std::lock_guard<std::mutex> lk(em);
+        if (!error.empty())
+            throw std::runtime_error("stream_ngeom tessellation failed: " + error);
+    }
+    return total;
+}
+
+static adacpp::ngeom::TessParams ngeom_tess_params(const std::string &pipeline, double deflection, double angular_deg,
+                                                   double model_scale, bool pin_boundary, bool capture_face_ranges) {
+    auto track = adacpp::ngeom::parse_track(pipeline);
+    if (!track) // unknown track = error, not a silent fallback (same contract as stream_step_to_glb)
+        throw std::runtime_error("unknown tessellation pipeline: '" + pipeline + "'");
+    adacpp::ngeom::TessParams tp;
+    tp.track = *track;
+    tp.libtess2.pin_boundary = pin_boundary;
+    tp.deflection = deflection;
+    tp.max_angle = angular_deg * 3.14159265358979323846 / 180.0;
+    tp.model_scale = model_scale; // >0 => adaptive per-surface density
+    tp.capture_face_ranges = capture_face_ranges;
+    return tp;
+}
+
+// The GLB/OBJ/STL emit audit dict: walk counters + the per-conversion tessellation-health
+// counters (the same numbers the [GEOMHEALTH-JSON] stderr line carries), so callers can gate on
+// faces_dropped without scraping stderr. Field names match ngeom_emit_stats_dict where shared.
+static nb::dict ngeom_tess_stats_dict(const NgeomTessStats &st, double unit_scale) {
+    nb::dict d;
+    d["solids_in"] = st.solids_in;
+    d["solids_out"] = st.solids_out;
+    d["solids_skipped"] = st.solids_skipped;
+    d["instances_out"] = st.instances_out;
+    d["unit_scale"] = unit_scale;
+    d["triangles"] = st.triangles;
+    d["faces_total"] = adacpp::ngeom::tess_total_faces();
+    d["faces_dropped"] = adacpp::ngeom::tess_dropped_faces();
+    d["faces_suspect"] = adacpp::ngeom::tess_suspect_faces();
+    nb::dict reasons;
+    for (const auto &[k, v] : adacpp::ngeom::tess_dropped_by_surface())
+        reasons[k.c_str()] = v;
+    d["drop_reasons"] = reasons;
+    return d;
+}
+
+// NGEOM records -> GLB file. Record front-end + the stream_step_to_glb back half: one spill lane
+// (ordered commits keep output deterministic), merge-by-colour GLB with the viewer's structure
+// (per-solid draw ranges, assembly paths from the records, inline EXT_meshopt when `meshopt`).
+static nb::dict stream_ngeom_to_glb_impl(nb::iterable records, const std::string &out_path, double deflection,
+                                         double angular_deg, int num_threads, bool meshopt, double model_scale,
+                                         const std::string &pipeline, bool pin_boundary, double unit_scale) {
+    adacpp::prof::StepProfiler prof("stream_ngeom_to_glb");
+    adacpp::tune_malloc_for_streaming();    // bound streaming peak RSS before the pool
+    adacpp::ngeom::reset_tess_face_stats(); // count dropped faces across this conversion (audit health flag)
+    // capture_face_ranges: per-face colours (when a blob carries them) must split into per-colour
+    // materials, matching the STEP core; the picking extras stay off (ranges dropped after split).
+    adacpp::ngeom::TessParams tp = ngeom_tess_params(pipeline, deflection, angular_deg, model_scale, pin_boundary,
+                                                     /*capture_face_ranges=*/true);
+    int nthreads = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
+
+    std::string tmpl = adacpp::temp_template("adacpp_glb");
+    char *dir = ::mkdtemp(tmpl.data());
+    if (!dir)
+        throw std::runtime_error("stream_ngeom_to_glb: cannot create spill dir");
+    const std::string spill = dir;
+    bool ok = false;
+    NgeomTessStats st;
+    try { // lane scoped so its temp files are removed before the rmdir
+        adacpp::glb::GlbSpillWriter lane(spill, 0);
+        st = stream_ngeom_tess_pump(records, tp, nthreads, unit_scale, /*split_by_face_colour=*/true,
+                                    [&](std::vector<adacpp::glb::GlbSolid> &parts) {
+                                        for (adacpp::glb::GlbSolid &part : parts)
+                                            lane.add(part); // spilled/buffered immediately
+                                    });
+        prof.phase("stream(decode+tess+spill)");
+        std::vector<adacpp::glb::GlbSpillWriter *> lane_ptrs{&lane};
+        // Schema-complete ADA_EXT_data (empty design/sim lists) — same default as the STEP core.
+        const std::string ada_ext = adacpp::ada_ext::AdaDesignAndAnalysisExtension{}.to_json();
+        ok = adacpp::glb::write_glb_merged(out_path, lane_ptrs, ada_ext, meshopt);
+        prof.phase(meshopt ? "write_glb_merged(meshopt)" : "write_glb_merged");
+    } catch (...) {
+        ::rmdir(spill.c_str());
+        throw;
+    }
+    ::rmdir(spill.c_str());
+    prof.note("threads", nthreads);
+    if (adacpp::ngeom::tess_dropped_faces() || adacpp::ngeom::tess_suspect_faces())
+        std::fprintf(stderr, "[GEOMHEALTH-JSON] %s\n", adacpp::ngeom::tess_geomhealth_json().c_str());
+    if (!ok)
+        throw std::runtime_error("stream_ngeom_to_glb: GLB write failed");
+    return ngeom_tess_stats_dict(st, unit_scale);
+}
+
+// NGEOM records -> binary STL / welded Wavefront OBJ. Record front-end + the stream_step_to_mesh
+// back half (one MeshLane; each instance's world placement baked at commit; assemble_lanes writes
+// the final file). Ordered commits keep the output byte-deterministic.
+static nb::dict stream_ngeom_to_mesh_impl(nb::iterable records, const std::string &out_path, const std::string &fmt_s,
+                                          double deflection, double angular_deg, int num_threads, double model_scale,
+                                          const std::string &pipeline, bool pin_boundary, double unit_scale) {
+    adacpp::MeshFormat fmt;
+    if (fmt_s == "obj" || fmt_s == "OBJ")
+        fmt = adacpp::MeshFormat::OBJ;
+    else if (fmt_s == "stl" || fmt_s == "STL")
+        fmt = adacpp::MeshFormat::STL;
+    else
+        throw std::runtime_error("stream_ngeom_to_mesh: fmt must be 'obj' or 'stl', got '" + fmt_s + "'");
+    static const std::array<float, 16> kIdentity = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+    adacpp::prof::StepProfiler prof("stream_ngeom_to_mesh");
+    adacpp::tune_malloc_for_streaming();
+    adacpp::ngeom::reset_tess_face_stats();
+    adacpp::ngeom::TessParams tp = ngeom_tess_params(pipeline, deflection, angular_deg, model_scale, pin_boundary,
+                                                     /*capture_face_ranges=*/false);
+    int nthreads = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
+
+    std::string tmpl = adacpp::temp_template("adacpp_mesh");
+    char *dir = ::mkdtemp(tmpl.data());
+    if (!dir)
+        throw std::runtime_error("stream_ngeom_to_mesh: cannot create spill dir");
+    const std::string spill = dir;
+    long total = -1;
+    NgeomTessStats st;
+    try {
+        std::deque<adacpp::meshwrite::MeshLane> lanes;
+        lanes.emplace_back(spill, 0, fmt);
+        adacpp::meshwrite::MeshLane &lane = lanes.front();
+        st = stream_ngeom_tess_pump(
+            records, tp, nthreads, unit_scale, /*split_by_face_colour=*/false,
+            [&](std::vector<adacpp::glb::GlbSolid> &parts) {
+                for (adacpp::glb::GlbSolid &part : parts) {
+                    const size_t ninst = part.transforms.empty() ? 1 : part.transforms.size();
+                    for (size_t k = 0; k < ninst; ++k) {
+                        const std::array<float, 16> &M = part.transforms.empty() ? kIdentity : part.transforms[k];
+                        if (fmt == adacpp::MeshFormat::OBJ) {
+                            lane.add_instance(part.positions, part.indices, M, /*usc=*/1.0f); // welded, pre-scaled
+                        } else {
+                            const std::vector<float> &P = part.positions;
+                            const std::vector<uint32_t> &I = part.indices;
+                            for (size_t e = 0; e + 2 < I.size(); e += 3) {
+                                float w0[3], w1[3], w2[3];
+                                adacpp::meshwrite::bake(M, 1.0f, &P[3 * I[e]], w0);
+                                adacpp::meshwrite::bake(M, 1.0f, &P[3 * I[e + 1]], w1);
+                                adacpp::meshwrite::bake(M, 1.0f, &P[3 * I[e + 2]], w2);
+                                lane.facet(w0, w1, w2);
+                            }
+                        }
+                    }
+                }
+            });
+        prof.phase("stream(decode+tess+bake)");
+        lane.flush();
+        total = adacpp::meshwrite::assemble_lanes(out_path, lanes, fmt);
+        prof.phase("assemble");
+        lanes.clear(); // remove lane temp files (destructors) before the rmdir
+    } catch (...) {
+        ::rmdir(spill.c_str());
+        throw;
+    }
+    ::rmdir(spill.c_str());
+    prof.note("threads", nthreads);
+    if (adacpp::ngeom::tess_dropped_faces() || adacpp::ngeom::tess_suspect_faces())
+        std::fprintf(stderr, "[GEOMHEALTH-JSON] %s\n", adacpp::ngeom::tess_geomhealth_json().c_str());
+    if (total < 0)
+        throw std::runtime_error("stream_ngeom_to_mesh: file write failed");
+    return ngeom_tess_stats_dict(st, unit_scale);
 }
 
 // One NGEOM blob -> the SPF text of its IFC geometry-body entity graph ONLY (the IfcAdvancedBrep /
@@ -4494,6 +4880,33 @@ void cad_module(nb::module_ &m) {
         "IfcSpatialZone tree from the record paths; multi-instance solids share geometry via "
         "IfcMappedItem. Records are pulled lazily (generator-friendly, bounded memory). schema: "
         "'IFC4X3_ADD2' | 'IFC4'. Returns the losslessness audit dict.");
+
+    m.def(
+        "stream_ngeom_to_glb", &stream_ngeom_to_glb_impl, "records"_a, "out_path"_a, "deflection"_a = 0.0,
+        "angular_deg"_a = 20.0, "num_threads"_a = 0, "meshopt"_a = true, "model_scale"_a = 0.0,
+        "pipeline"_a = "libtess2", "pin_boundary"_a = true, "unit_scale"_a = 1.0,
+        "Native GLB writer from a stream of NGEOM records (same record shape + lazy pull as "
+        "stream_ngeom_to_step). Decodes each blob, tessellates it on a worker pool (num_threads=0 = "
+        "cgroup-aware auto; pipeline: 'libtess2' default / 'cdt'), bakes each instance's world "
+        "placement + colour and writes the merge-by-colour GLB matching the adapy viewer's structure "
+        "(per-solid draw ranges + assembly paths from the records; meshopt=True bakes "
+        "EXT_meshopt_compression inline). unit_scale = metres per model unit — positions and "
+        "instance translations are scaled so the GLB is always metres. model_scale > 0 enables "
+        "model-relative adaptive tessellation density. Deterministic: output bytes depend only on "
+        "the records and knobs, never on thread count or scheduling. Returns the audit dict "
+        "(solids_in/out/skipped, instances_out, triangles, faces_total/dropped/suspect, "
+        "drop_reasons — the [GEOMHEALTH-JSON] counters).");
+
+    m.def(
+        "stream_ngeom_to_mesh", &stream_ngeom_to_mesh_impl, "records"_a, "out_path"_a, "fmt"_a, "deflection"_a = 0.0,
+        "angular_deg"_a = 20.0, "num_threads"_a = 0, "model_scale"_a = 0.0, "pipeline"_a = "libtess2",
+        "pin_boundary"_a = true, "unit_scale"_a = 1.0,
+        "Native binary-STL / welded-OBJ writer from a stream of NGEOM records (same record shape + "
+        "lazy pull as stream_ngeom_to_step; fmt: 'stl' | 'obj'). Tessellates on a worker pool and "
+        "bakes each instance's world placement straight into the mesh file — no Python scene, no "
+        "whole-model buffer. unit_scale = metres per model unit (output is always metres). "
+        "Deterministic: output bytes depend only on the records and knobs, never on thread count. "
+        "Returns the same audit dict as stream_ngeom_to_glb.");
 
     m.def(
         "ngeom_to_ifc_body_spf",

--- a/src/cad/cad_py_wrap.cpp
+++ b/src/cad/cad_py_wrap.cpp
@@ -3474,9 +3474,13 @@ static adacpp::ifc_emit::FileStats write_ifc_file_parallel_impl(const std::strin
 }
 
 // Native parallel STEP->STEP (AP242). Mirrors the parallel IFC writer: shared StreamIndex, per-worker
-// Resolver, LPT, per-worker lanes, local ids -> atomic-reserve -> renumber. Instances are BAKED
-// (per-instance transform applied to the geometry) — v1 flat parts (no NAUO assembly tree). nth=1 =
-// serial. NO parse_cache_ bounding (per-worker clear_geom_cache per solid). Round-trip-lossless.
+// Resolver, LPT, per-worker lanes, local ids -> atomic-reserve -> renumber. Multi-instance B-rep
+// solids with rigid placements are emitted ONCE as a shared prototype + per-placement NAUO/CDSR/
+// ITEM_DEFINED_TRANSFORMATION references (the AP242 assembly-instancing pattern both native stream
+// readers and OCC consume — see emit_step_mapped_instances); everything else keeps the baked form
+// (per-instance transform applied to the geometry). ADACPP_STEP_BAKE_INSTANCES=1 forces all-baked.
+// nth=1 = serial. NO parse_cache_ bounding (per-worker clear_geom_cache per solid).
+// Round-trip-lossless.
 static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_path, const std::string &out_path,
                                                         double deflection, double angular_deg, int num_threads,
                                                         long max_solids) {
@@ -3505,7 +3509,14 @@ static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_pa
             roots[i] = cost[i].second;
     }
     prof.phase("lpt_order");
-    const long K = 13;
+    // Mapped instancing needs a shared assembly-root block: #14..#17 = root PRODUCT chain, #18 =
+    // the world SHAPE_REPRESENTATION (its item list is only known after all lanes ran, so the
+    // record itself is written at assemble time — forward references are legal SPF). Ids <= K are
+    // protected from renumbering, so reserve them only when instancing can actually occur; a flat
+    // source keeps the old K=13 layout byte-for-byte.
+    const bool mapped_on = !step_bake_instances_forced() && master.any_multi_instance();
+    const long K = mapped_on ? 18 : 13;
+    const long ROOT_PD = 16, WORLD_REP = 18, IDENTITY_AXIS = 13;
     std::atomic<long> id_counter{K + 1};
     int nth = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
     if (nth > (int) roots.size())
@@ -3520,6 +3531,8 @@ static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_pa
         std::string path, buf;
         adacpp::ifc_emit::EmitStats stats;
         long solids_out = 0;
+        long instances_out = 0;
+        std::vector<long> world_axes; // global ids of per-instance AXIS2s -> the world rep's items
     };
     std::vector<Lane> lanes(nth);
     for (int t = 0; t < nth; ++t) {
@@ -3554,37 +3567,27 @@ static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_pa
             solids_in.fetch_add(1, std::memory_order_relaxed);
             prof.solid(root.faces.size());
             ++w_solids;
-            // One baked part per instance (or one identity part when flat).
-            size_t ninst = root.transforms.empty() ? 1 : root.transforms.size();
             bool any = false;
-            for (size_t k = 0; k < ninst; ++k) {
-                double tf[16];
-                const double *tfp = nullptr;
-                if (!root.transforms.empty()) {
-                    // ng:: transforms are column-major glTF; StepBrepEmitter wants row-major.
-                    const std::array<float, 16> &M = root.transforms[k];
-                    tf[0] = M[0];
-                    tf[1] = M[4];
-                    tf[2] = M[8];
-                    tf[3] = M[12];
-                    tf[4] = M[1];
-                    tf[5] = M[5];
-                    tf[6] = M[9];
-                    tf[7] = M[13];
-                    tf[8] = M[2];
-                    tf[9] = M[6];
-                    tf[10] = M[10];
-                    tf[11] = M[14];
-                    tfp = tf;
-                }
+            if (mapped_on && step_mapped_eligible(root)) {
+                // Shared prototype ONCE (identity frame) + one NAUO/CDSR/IDT reference per placement.
                 sb.clear();
-                StepBrepEmitter em(K, tfp, deflection, angular_deg);
-                bool ok = emit_solid_step(em, sb, root, roots[i]);
-                long n = em.current_id() - K;
-                if (ok) {
+                StepBrepEmitter em(K, nullptr, deflection, angular_deg);
+                long rep_id = 0;
+                long pd = emit_solid_step(em, sb, root, roots[i], &rep_id);
+                if (pd) {
+                    std::string nm =
+                        root.id.empty() ? ("solid_" + std::to_string(roots[i])) : adacpp::ifc_emit::ifc_str(root.id);
+                    std::vector<long> axes_local;
+                    emit_step_mapped_instances(em, sb, rep_id, pd, nm, roots[i], root.transforms, ROOT_PD, WORLD_REP,
+                                               IDENTITY_AXIS, axes_local);
+                    long n = em.current_id() - K;
                     long gbase = id_counter.fetch_add(n, std::memory_order_relaxed);
-                    renumber_into(L.buf, sb, gbase - (K + 1), K);
+                    long offset = gbase - (K + 1);
+                    renumber_into(L.buf, sb, offset, K);
+                    for (long a : axes_local)
+                        L.world_axes.push_back(a + offset);
                     any = true;
+                    L.instances_out += (long) root.transforms.size();
                     const auto &s = em.stats();
                     L.stats.faces_in += s.faces_in;
                     L.stats.faces_out += s.faces_out;
@@ -3594,6 +3597,49 @@ static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_pa
                     L.stats.edges_degenerate += s.edges_degenerate;
                     for (const auto &[rk, rv] : s.drop_reasons)
                         L.stats.drop_reasons[rk] += rv;
+                }
+            } else {
+                // One baked part per instance (or one identity part when flat).
+                size_t ninst = root.transforms.empty() ? 1 : root.transforms.size();
+                for (size_t k = 0; k < ninst; ++k) {
+                    double tf[16];
+                    const double *tfp = nullptr;
+                    if (!root.transforms.empty()) {
+                        // ng:: transforms are column-major glTF; StepBrepEmitter wants row-major.
+                        const std::array<float, 16> &M = root.transforms[k];
+                        tf[0] = M[0];
+                        tf[1] = M[4];
+                        tf[2] = M[8];
+                        tf[3] = M[12];
+                        tf[4] = M[1];
+                        tf[5] = M[5];
+                        tf[6] = M[9];
+                        tf[7] = M[13];
+                        tf[8] = M[2];
+                        tf[9] = M[6];
+                        tf[10] = M[10];
+                        tf[11] = M[14];
+                        tfp = tf;
+                    }
+                    sb.clear();
+                    StepBrepEmitter em(K, tfp, deflection, angular_deg);
+                    bool ok = emit_solid_step(em, sb, root, roots[i]);
+                    long n = em.current_id() - K;
+                    if (ok) {
+                        long gbase = id_counter.fetch_add(n, std::memory_order_relaxed);
+                        renumber_into(L.buf, sb, gbase - (K + 1), K);
+                        any = true;
+                        ++L.instances_out;
+                        const auto &s = em.stats();
+                        L.stats.faces_in += s.faces_in;
+                        L.stats.faces_out += s.faces_out;
+                        L.stats.faces_dropped += s.faces_dropped;
+                        L.stats.edges_analytic += s.edges_analytic;
+                        L.stats.edges_polyline_approx += s.edges_polyline_approx;
+                        L.stats.edges_degenerate += s.edges_degenerate;
+                        for (const auto &[rk, rv] : s.drop_reasons)
+                            L.stats.drop_reasons[rk] += rv;
+                    }
                 }
             }
             if (any)
@@ -3627,6 +3673,31 @@ static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_pa
     }
     std::string hdr = step_header_block(master.unit_scale());
     std::fwrite(hdr.data(), 1, hdr.size(), out_fp);
+    // Shared assembly-root block for mapped instances: root PRODUCT chain (#14..#17) + the world
+    // SHAPE_REPRESENTATION #18 listing every instance AXIS2 among its items (deferred until now
+    // because the item list spans all lanes; statement order is irrelevant in SPF). Skipped when no
+    // solid actually took the mapped path — the unused reserved ids are legal gaps.
+    if (mapped_on) {
+        std::vector<long> all_axes;
+        for (int t = 0; t < nth; ++t)
+            all_axes.insert(all_axes.end(), lanes[t].world_axes.begin(), lanes[t].world_axes.end());
+        if (!all_axes.empty()) {
+            std::string rb;
+            rb += "#14=PRODUCT('model','model','',(#3));\n";
+            rb += "#15=PRODUCT_DEFINITION_FORMATION('','',#14);\n";
+            rb += "#16=PRODUCT_DEFINITION('design','',#15,#4);\n";
+            rb += "#17=PRODUCT_DEFINITION_SHAPE('','',#16);\n";
+            rb += "#18=SHAPE_REPRESENTATION('model',(#13";
+            for (long a : all_axes) {
+                rb += ",#";
+                rb += std::to_string(a);
+            }
+            rb += "),#9);\n";
+            long sdr_id = id_counter.fetch_add(1, std::memory_order_relaxed);
+            rb += "#" + std::to_string(sdr_id) + "=SHAPE_DEFINITION_REPRESENTATION(#17,#18);\n";
+            std::fwrite(rb.data(), 1, rb.size(), out_fp);
+        }
+    }
     std::vector<char> io(1 << 20);
     for (int t = 0; t < nth; ++t) {
         Lane &L = lanes[t];
@@ -3637,6 +3708,7 @@ static adacpp::ifc_emit::FileStats write_step_file_impl(const std::string &in_pa
             std::fclose(lf);
         }
         fs.solids_out += L.solids_out;
+        fs.instances_out += L.instances_out;
         fs.geom.faces_in += L.stats.faces_in;
         fs.geom.faces_out += L.stats.faces_out;
         fs.geom.faces_dropped += L.stats.faces_dropped;
@@ -3717,6 +3789,7 @@ static void step_parity_impl(const std::string &in_path, double deflection, doub
     int nth = num_threads > 0 ? num_threads : (int) adacpp::effective_concurrency();
     if (nth > (int) roots.size())
         nth = std::max(1, (int) roots.size());
+    const bool bake_forced = step_bake_instances_forced(); // mirror write_step_file_impl's mode
     std::vector<ParityFormat> ifc_lanes(nth), step_lanes(nth);
     std::atomic<size_t> next{0};
     std::atomic<long> solids_in{0};
@@ -3747,34 +3820,46 @@ static void step_parity_impl(const std::string &in_path, double deflection, doub
             LI.instances += (long) proxies.size();
             accum_geom(LI.geom, emi.stats());
 
-            // ── STEP: one baked part per instance (matches write_step_file_impl) ──
-            size_t ninst = root.transforms.empty() ? 1 : root.transforms.size();
+            // ── STEP: mirror write_step_file_impl — shared prototype + per-placement references
+            // for mapped-eligible solids (geometry counted ONCE, instances = placements), else one
+            // baked part per instance ──
             bool any = false;
-            for (size_t k = 0; k < ninst; ++k) {
-                double tf[16];
-                const double *tfp = nullptr;
-                if (!root.transforms.empty()) {
-                    const std::array<float, 16> &M = root.transforms[k];
-                    tf[0] = M[0];
-                    tf[1] = M[4];
-                    tf[2] = M[8];
-                    tf[3] = M[12];
-                    tf[4] = M[1];
-                    tf[5] = M[5];
-                    tf[6] = M[9];
-                    tf[7] = M[13];
-                    tf[8] = M[2];
-                    tf[9] = M[6];
-                    tf[10] = M[10];
-                    tf[11] = M[14];
-                    tfp = tf;
-                }
+            if (!bake_forced && step_mapped_eligible(root)) {
                 sb.clear();
-                StepBrepEmitter ems(13, tfp, deflection, angular_deg);
+                StepBrepEmitter ems(13, nullptr, deflection, angular_deg);
                 if (emit_solid_step(ems, sb, root, roots[i])) {
                     any = true;
-                    ++LS.instances;
+                    LS.instances += (long) root.transforms.size();
                     accum_geom(LS.geom, ems.stats());
+                }
+            } else {
+                size_t ninst = root.transforms.empty() ? 1 : root.transforms.size();
+                for (size_t k = 0; k < ninst; ++k) {
+                    double tf[16];
+                    const double *tfp = nullptr;
+                    if (!root.transforms.empty()) {
+                        const std::array<float, 16> &M = root.transforms[k];
+                        tf[0] = M[0];
+                        tf[1] = M[4];
+                        tf[2] = M[8];
+                        tf[3] = M[12];
+                        tf[4] = M[1];
+                        tf[5] = M[5];
+                        tf[6] = M[9];
+                        tf[7] = M[13];
+                        tf[8] = M[2];
+                        tf[9] = M[6];
+                        tf[10] = M[10];
+                        tf[11] = M[14];
+                        tfp = tf;
+                    }
+                    sb.clear();
+                    StepBrepEmitter ems(13, tfp, deflection, angular_deg);
+                    if (emit_solid_step(ems, sb, root, roots[i])) {
+                        any = true;
+                        ++LS.instances;
+                        accum_geom(LS.geom, ems.stats());
+                    }
                 }
             }
             if (any)
@@ -4080,6 +4165,7 @@ void cad_module(nb::module_ &m) {
             nb::dict d;
             d["solids_in"] = fs.solids_in;
             d["solids_out"] = fs.solids_out;
+            d["instances_out"] = fs.instances_out;
             d["unit_scale"] = fs.unit_scale;
             d["faces_in"] = fs.geom.faces_in;
             d["faces_out"] = fs.geom.faces_out;
@@ -4096,7 +4182,10 @@ void cad_module(nb::module_ &m) {
         "in_path"_a, "out_path"_a, "deflection"_a = 2.0, "angular_deg"_a = 20.0, "max_solids"_a = 0,
         "num_threads"_a = 0,
         "Native parallel STEP->STEP (AP242): re-export each solid's analytic B-rep as a "
-        "MANIFOLD_SOLID_BREP part (instances baked), no OCC. Returns the losslessness audit dict.");
+        "MANIFOLD_SOLID_BREP part, no OCC. Multi-instance B-rep solids with rigid placements are "
+        "written once as a shared prototype + per-placement NAUO/CDSR references (AP242 assembly "
+        "instancing); other solids are baked per instance. ADACPP_STEP_BAKE_INSTANCES=1 forces the "
+        "all-baked form. Returns the losslessness audit dict (instances_out = placed occurrences).");
 
     // Cross-format parity in ONE parse (the fan-out of stream_step_to_ifc + stream_step_to_step):
     // resolve each root once, run both emitters, count what each format preserves — no file output.

--- a/src/cad/ifc_emit.h
+++ b/src/cad/ifc_emit.h
@@ -682,6 +682,10 @@ inline std::string ifc_str(const std::string &s) {
 
 struct FileStats {
     long solids_in = 0, solids_out = 0;
+    // Placed occurrences written (baked parts + mapped-instance references). Reported by the
+    // STEP->STEP writer so shared-prototype instancing keeps the audit's placed-instance
+    // semantics even though geometry is serialised once per prototype; 0 elsewhere.
+    long instances_out = 0;
     double unit_scale = 1.0; // metres per file length-unit (declared in the IFC header)
     // IFC->STEP coverage: roots seen vs roots that yielded no resolvable B-rep (non-advanced-brep
     // geometry — extrusion/CSG/tessellated — which the analytic reader can't represent). Non-zero

--- a/src/cad/step_emit.h
+++ b/src/cad/step_emit.h
@@ -67,7 +67,7 @@ public:
     // Emit an extruded-area solid -> EXTRUDED_AREA_SOLID id (0 on failure). The instance transform is
     // baked into the Position (world frame = tf_ o ex.frame); the 2D profile points + the local extrude
     // direction are emitted raw (relative to Position), matching the ng:: extrusion tessellation.
-    long emit_extrusion(std::string &out, const ExtrusionN &ex) {
+    long emit_extrusion(std::string &out, const ExtrusionN &ex, const std::string &name = "") {
         if (!ex.profile || ex.profile->bounds.empty() || !ex.profile->bounds[0].loop)
             return 0;
         const LoopN &lp = *ex.profile->bounds[0].loop;
@@ -87,13 +87,13 @@ public:
         long pos = emit(out, "AXIS2_PLACEMENT_3D('',#" + std::to_string(pt_raw(out, wo)) + ",#" +
                                  std::to_string(dir_raw(out, wz)) + ",#" + std::to_string(dir_raw(out, wx)) + ")");
         long ed = dir_raw(out, ex.direction); // local to Position
-        return emit(out, "EXTRUDED_AREA_SOLID('',#" + std::to_string(prof) + ",#" + std::to_string(pos) + ",#" +
-                             std::to_string(ed) + "," + ifc_real(ex.depth) + ")");
+        return emit(out, "EXTRUDED_AREA_SOLID('" + name + "',#" + std::to_string(prof) + ",#" + std::to_string(pos) +
+                             ",#" + std::to_string(ed) + "," + ifc_real(ex.depth) + ")");
     }
 
     // Emit a revolved-area solid -> REVOLVED_AREA_SOLID id (0 on failure). Instance transform baked into
     // Position (caller ensures it's rigid); the 2D profile + the local revolution Axis emitted raw.
-    long emit_revolve(std::string &out, const RevolveN &rv) {
+    long emit_revolve(std::string &out, const RevolveN &rv, const std::string &name = "") {
         if (!rv.profile || rv.profile->bounds.empty() || !rv.profile->bounds[0].loop)
             return 0;
         const LoopN &lp = *rv.profile->bounds[0].loop;
@@ -114,13 +114,13 @@ public:
                                  std::to_string(dir_raw(out, wz)) + ",#" + std::to_string(dir_raw(out, wx)) + ")");
         long ax = emit(out, "AXIS1_PLACEMENT('',#" + std::to_string(pt_raw(out, rv.axis_origin)) + ",#" +
                                 std::to_string(dir_raw(out, rv.axis_dir)) + ")"); // local to Position
-        return emit(out, "REVOLVED_AREA_SOLID('',#" + std::to_string(prof) + ",#" + std::to_string(pos) + ",#" +
-                             std::to_string(ax) + "," + ifc_real(rv.angle) + ")");
+        return emit(out, "REVOLVED_AREA_SOLID('" + name + "',#" + std::to_string(prof) + ",#" + std::to_string(pos) +
+                             ",#" + std::to_string(ax) + "," + ifc_real(rv.angle) + ")");
     }
 
     // A disk/annulus swept along a directrix -> SWEPT_DISK_SOLID (radius recovered from the circular
     // profile; directrix = origin[] baked to world via frame o tf). Matches the ng:: swept-disk.
-    long emit_swept_disk(std::string &out, const SweepN &sw) {
+    long emit_swept_disk(std::string &out, const SweepN &sw, const std::string &name = "") {
         if (sw.origin.size() < 2 || !sw.profile || sw.profile->bounds.empty() || !sw.profile->bounds[0].loop)
             return 0;
         const LoopN &lp = *sw.profile->bounds[0].loop;
@@ -147,14 +147,14 @@ public:
             dids.push_back(pt_raw(out, tp(sw.frame.to_world(o.x, o.y, o.z))));
         long directrix = emit(out, "POLYLINE(''," + refs(dids) + ")");
         std::string inner_s = inner > 1e-9 ? ifc_real(inner) : "$";
-        return emit(out, "SWEPT_DISK_SOLID('',#" + std::to_string(directrix) + "," + ifc_real(radius) + "," + inner_s +
-                             ",$,$)");
+        return emit(out, "SWEPT_DISK_SOLID('" + name + "',#" + std::to_string(directrix) + "," + ifc_real(radius) +
+                             "," + inner_s + ",$,$)");
     }
     // A sphere -> CSG_SOLID over a SPHERE primitive (centre baked to world).
-    long emit_sphere(std::string &out, const SphereN &sp) {
+    long emit_sphere(std::string &out, const SphereN &sp, const std::string &name = "") {
         long ctr = pt_raw(out, tp(sp.frame.o));
         long sph = emit(out, "SPHERE(''," + ifc_real(sp.radius) + ",#" + std::to_string(ctr) + ")");
-        return emit(out, "CSG_SOLID('',#" + std::to_string(sph) + ")");
+        return emit(out, "CSG_SOLID('" + name + "',#" + std::to_string(sph) + ")");
     }
 
     // Emit a boolean-operand solid -> its STEP id (0 if unrepresentable). Recursive for nested booleans.

--- a/src/cad/step_to_mesh_stream.h
+++ b/src/cad/step_to_mesh_stream.h
@@ -153,6 +153,71 @@ inline void bake(const std::array<float, 16> &M, float usc, const float p[3], fl
     out[2] = usc * (M[2] * p[0] + M[6] * p[1] + M[10] * p[2] + M[14]);
 }
 
+// Assemble the final STL/OBJ file from the lane temp files. STL: 80-byte header + facet count +
+// each lane's raw 50-byte facets. OBJ: every lane's welded 'v' file in lane order, then each lane's
+// binary index triples rewritten as 1-based 'f' lines with a running per-lane global vertex base.
+// Lanes must be flush()ed first. Returns the total triangle count, or -1 on I/O error. Shared by
+// stream_step_to_mesh and the NGEOM-record mesh emitter (stream_ngeom_to_mesh).
+inline long assemble_lanes(const std::string &out_path, std::deque<MeshLane> &lanes, MeshFormat fmt) {
+    uint64_t total = 0;
+    for (MeshLane &l : lanes)
+        total += l.tris;
+    std::FILE *out = std::fopen(out_path.c_str(), "wb");
+    if (!out)
+        return -1;
+    auto copy_lane = [&](const std::string &p) {
+        std::FILE *in = std::fopen(p.c_str(), "rb");
+        if (!in)
+            return;
+        std::vector<char> b(1 << 20);
+        size_t n;
+        while ((n = std::fread(b.data(), 1, b.size(), in)) > 0)
+            std::fwrite(b.data(), 1, n, out);
+        std::fclose(in);
+    };
+    if (fmt == MeshFormat::STL) {
+        char header[80] = {0};
+        std::fwrite(header, 1, 80, out);
+        uint32_t cnt = (uint32_t) total;
+        std::fwrite(&cnt, 4, 1, out);
+        for (MeshLane &l : lanes)
+            copy_lane(l.path);
+    } else { // OBJ: concat welded 'v' files, then faces from the binary index lanes (+global base)
+        for (MeshLane &l : lanes)
+            copy_lane(l.path); // .objv vertex files, in lane order
+        std::vector<char> fb;
+        fb.reserve(1 << 20);
+        uint64_t base = 0; // verts written by prior lanes (1-based -> +1 at emit)
+        for (MeshLane &l : lanes) {
+            std::FILE *fin = std::fopen(l.fpath.c_str(), "rb");
+            if (fin) {
+                std::vector<uint32_t> ib(3 << 16);
+                size_t got;
+                while ((got = std::fread(ib.data(), sizeof(uint32_t), ib.size(), fin)) >= 3) {
+                    for (size_t e = 0; e + 2 < got; e += 3) {
+                        char line[64];
+                        int n = std::snprintf(line, sizeof line, "f %llu %llu %llu\n",
+                                              (unsigned long long) (base + ib[e] + 1),
+                                              (unsigned long long) (base + ib[e + 1] + 1),
+                                              (unsigned long long) (base + ib[e + 2] + 1));
+                        fb.insert(fb.end(), line, line + n);
+                    }
+                    if (fb.size() >= (1 << 20)) {
+                        std::fwrite(fb.data(), 1, fb.size(), out);
+                        fb.clear();
+                    }
+                }
+                std::fclose(fin);
+            }
+            base += l.vcount;
+        }
+        if (!fb.empty())
+            std::fwrite(fb.data(), 1, fb.size(), out);
+    }
+    std::fclose(out);
+    return (long) total;
+}
+
 } // namespace meshwrite
 
 // Returns the number of triangles written, or -1 on I/O error.
@@ -307,66 +372,8 @@ inline long stream_step_to_mesh(const std::string &in_path, const std::string &o
         th.join();
     prof.phase("stream(resolve+tess+bake)");
 
-    uint64_t total = 0;
-    for (auto &l : lanes)
-        total += l.tris;
-
     // ── assemble the final file from the lane temp files ──
-    bool ok = false;
-    std::FILE *out = std::fopen(out_path.c_str(), "wb");
-    if (out) {
-        auto copy_lane = [&](const std::string &p) {
-            std::FILE *in = std::fopen(p.c_str(), "rb");
-            if (!in)
-                return;
-            std::vector<char> b(1 << 20);
-            size_t n;
-            while ((n = std::fread(b.data(), 1, b.size(), in)) > 0)
-                std::fwrite(b.data(), 1, n, out);
-            std::fclose(in);
-        };
-        if (fmt == MeshFormat::STL) {
-            char header[80] = {0};
-            std::fwrite(header, 1, 80, out);
-            uint32_t cnt = (uint32_t) total;
-            std::fwrite(&cnt, 4, 1, out);
-            for (auto &l : lanes)
-                copy_lane(l.path);
-        } else { // OBJ: concat welded 'v' files, then faces from the binary index lanes (+global base)
-            for (auto &l : lanes)
-                copy_lane(l.path); // .objv vertex files, in lane order
-            std::vector<char> fb;
-            fb.reserve(1 << 20);
-            uint64_t base = 0; // verts written by prior lanes (1-based -> +1 at emit)
-            for (auto &l : lanes) {
-                std::FILE *fin = std::fopen(l.fpath.c_str(), "rb");
-                if (fin) {
-                    std::vector<uint32_t> ib(3 << 16);
-                    size_t got;
-                    while ((got = std::fread(ib.data(), sizeof(uint32_t), ib.size(), fin)) >= 3) {
-                        for (size_t e = 0; e + 2 < got; e += 3) {
-                            char line[64];
-                            int n = std::snprintf(line, sizeof line, "f %llu %llu %llu\n",
-                                                  (unsigned long long) (base + ib[e] + 1),
-                                                  (unsigned long long) (base + ib[e + 1] + 1),
-                                                  (unsigned long long) (base + ib[e + 2] + 1));
-                            fb.insert(fb.end(), line, line + n);
-                        }
-                        if (fb.size() >= (1 << 20)) {
-                            std::fwrite(fb.data(), 1, fb.size(), out);
-                            fb.clear();
-                        }
-                    }
-                    std::fclose(fin);
-                }
-                base += l.vcount;
-            }
-            if (!fb.empty())
-                std::fwrite(fb.data(), 1, fb.size(), out);
-        }
-        std::fclose(out);
-        ok = true;
-    }
+    long total = meshwrite::assemble_lanes(out_path, lanes, fmt);
     prof.phase("assemble");
 
     lanes.clear(); // remove lane temp files (destructors)
@@ -375,7 +382,7 @@ inline long stream_step_to_mesh(const std::string &in_path, const std::string &o
     prof.note("threads", nthreads);
     if (adacpp::ngeom::tess_dropped_faces() || adacpp::ngeom::tess_suspect_faces())
         std::fprintf(stderr, "[GEOMHEALTH-JSON] %s\n", adacpp::ngeom::tess_geomhealth_json().c_str());
-    return ok ? (long) total : -1;
+    return total;
 }
 
 } // namespace adacpp

--- a/src/cadit/step/step_reader.h
+++ b/src/cadit/step/step_reader.h
@@ -703,6 +703,16 @@ public:
         clear_geom_cache();
     }
 
+    // True when at least one solid is placed more than once (CDSR instancing in the source). Lets
+    // the STEP writer decide UP FRONT (before any per-solid resolve) whether the output will carry
+    // the shared assembly-root block that mapped-instance emission hangs its NAUO/CDSR records off.
+    bool any_multi_instance() const {
+        for (const auto &kv : xform_map_)
+            if (kv.second.size() > 1)
+                return true;
+        return false;
+    }
+
     // Copy the already-built, read-only metadata maps from a master resolver so worker threads can
     // resolve+tessellate in parallel without each rebuilding (and re-reading) the metadata. Each
     // worker keeps its OWN per-solid caches; only these resolve-time maps are shared (by copy).

--- a/src/geom/neutral/ngeom_tessellate.cpp
+++ b/src/geom/neutral/ngeom_tessellate.cpp
@@ -1351,7 +1351,13 @@ Rect full_patch_rect(const Surface &s, const std::vector<std::vector<Uv>> &conto
     double area_ratio = std::abs(poly_area(contours[0])) / (du * dv);
     if (area_ratio < 0.995)
         return {};
-    return {clampd(umin, du0, du1), clampd(umax, du0, du1), clampd(vmin, dv0, dv1), clampd(vmax, dv0, dv1), true};
+    Rect r = {clampd(umin, du0, du1), clampd(umax, du0, du1), clampd(vmin, dv0, dv1), clampd(vmax, dv0, dv1), true};
+    // A loop lying (partly) outside the knot domain collapses under the clamp; a zero-extent rect
+    // would grid to zero triangles yet report success, silently dropping the face. Refuse it so the
+    // face falls through to the trim-respecting emit path (whose evaluation wraps periodics safely).
+    if (r.u1 - r.u0 < 1e-9 * ddu || r.v1 - r.v0 < 1e-9 * ddv)
+        return {};
+    return r;
 }
 
 Rect full_domain_bspline(const Surface &s, const std::vector<std::vector<Uv>> &contours) {
@@ -2347,6 +2353,38 @@ const char *face_to_mesh(const Surface &surf, const std::vector<Loop3> &loops3d,
             }
         }
         loops_uv.push_back({std::move(uv), std::move(pts3), w, interior_above});
+    }
+
+    // Periodic B-spline domain normalization: the per-point unwrap above is anchored to the FIRST
+    // point's inversion, which for a loop starting on the seam can come back on either branch —
+    // the whole loop then unwinds one full period OUTSIDE the knot domain (e.g. u in [-per, 0] for
+    // a domain [0, per]). Surface evaluation wraps (reduce_param), so triangles are right, but the
+    // B-spline rect fast paths (full_patch_rect) clamp their UV bbox INTO the domain, collapsing
+    // such a loop to a zero-width rect -> a "successful" grid of zero triangles -> dropped face
+    // (audit fe84a414 residual: CO2_Comp/P311/P351 closed NURBS tubes). Shift ALL loops together by
+    // the integer period multiple that centres their combined bbox in the domain; an integer-period
+    // shift is an exact identity for a closed direction.
+    if ((per_u || per_v) && !loops_uv.empty()) {
+        if (const auto *bs = dynamic_cast<const BSplineSurface *>(&surf)) {
+            double du0, du1, dv0, dv1;
+            bs->domain(du0, du1, dv0, dv1);
+            double umn = INF, umx = -INF, vmn = INF, vmx = -INF;
+            for (const LoopUv &l : loops_uv)
+                for (const Uv &p : l.uv) {
+                    umn = std::min(umn, p[0]);
+                    umx = std::max(umx, p[0]);
+                    vmn = std::min(vmn, p[1]);
+                    vmx = std::max(vmx, p[1]);
+                }
+            double ku = per_u ? std::round((0.5 * (du0 + du1) - 0.5 * (umn + umx)) / *per_u) : 0.0;
+            double kv = per_v ? std::round((0.5 * (dv0 + dv1) - 0.5 * (vmn + vmx)) / *per_v) : 0.0;
+            if (ku != 0.0 || kv != 0.0)
+                for (LoopUv &l : loops_uv)
+                    for (Uv &p : l.uv) {
+                        p[0] += ku * (per_u ? *per_u : 0.0);
+                        p[1] += kv * (per_v ? *per_v : 0.0);
+                    }
+        }
     }
 
     // Coverage health: expected trimmed surface area = |net signed UV-loop area| * surface Jacobian at

--- a/src/geom/neutral/ngeom_topology.h
+++ b/src/geom/neutral/ngeom_topology.h
@@ -266,8 +266,27 @@ struct OrientedEdgeN {
             // reversals (the align clip above already dropped the out-of-trim interior samples).
             if (pts.size() < 2)
                 return {start, end};
-            if ((pts.front() - start).norm() > (pts.back() - start).norm())
+            // CLOSED edge (start vertex == end vertex, e.g. the full B-spline circle rim of a
+            // closed NURBS tube): the endpoint-distance test below is a tie (front == back ==
+            // start), so a reversed (.F.) closed edge silently kept the curve's NATURAL direction.
+            // Both rim circles of such a tube then wound the SAME way in u, the face's single loop
+            // unwound to |w| = 2, and tessellate_periodic_winding (which requires |w| == 1) dropped
+            // the whole face (audit fe84a414: every STEP dropped-face bucket was this). Direction
+            // cannot come from the endpoints of a closed edge — apply the edge flags exactly as the
+            // circle/ellipse arc path does: reverse iff same_sense XOR orientation (align emitted
+            // the ring a->b, i.e. already same_sense-adjusted, so only the NET flag parity remains).
+            // "Closed" = the edge's own vertices coincide (usually the SAME VERTEX_POINT, so the
+            // distance is exactly 0; 1e-7 x edge length tolerates exporters that write two equal
+            // vertices). A nearly-closed OPEN edge (C-slit) keeps the endpoint-distance test.
+            double _len = 0.0;
+            for (size_t i = 1; i < pts.size(); ++i)
+                _len += (pts[i] - pts[i - 1]).norm();
+            if ((e_start - e_end).norm() <= std::max(1e-7 * _len, 1e-12)) {
+                if (same_sense != orientation)
+                    std::reverse(pts.begin(), pts.end());
+            } else if ((pts.front() - start).norm() > (pts.back() - start).norm()) {
                 std::reverse(pts.begin(), pts.end());
+            }
             pts.front() = start;
             pts.back() = end;
             // Decimate the fixed-density B-spline sample to the chord tolerance (see

--- a/tests/ngeom/test_tessellate.cpp
+++ b/tests/ngeom/test_tessellate.cpp
@@ -354,7 +354,105 @@ static void test_bspline_edge_samples_natural_domain() {
     CHECK(plen > 1.2 * (e.end - e.start).norm(), "B-spline edge polyline follows the curve, not a chord");
 }
 
+// A CLOSED B-spline edge (full NURBS circle, start vertex == end vertex) carries its direction
+// ONLY in same_sense/orientation — the endpoint-distance orientation test is a tie there. Regression
+// for the audit fe84a414 dropped-face family: a closed NURBS tube (9-pt rational circle x linear v)
+// bounded by seam + two full-circle edges, the top one ORIENTED_EDGE .F., silently kept the natural
+// direction, the single loop unwound to |w| = 2 and the whole face was dropped
+// (tessellate_periodic_winding requires |w| == 1).
+static void test_closed_bspline_edge_reversal_and_tube() {
+    const double r = 15.0, h = 3.0, w = std::sqrt(2.0) / 2.0;
+    auto circle_cps = [&](double z) {
+        return std::vector<Vec3>{{r, 0, z},  {r, r, z},  {0, r, z},  {-r, r, z}, {-r, 0, z},
+                                 {-r, -r, z}, {0, -r, z}, {r, -r, z}, {r, 0, z}};
+    };
+    const std::vector<double> cknots = {0, 0.25, 0.5, 0.75, 1.0};
+    const std::vector<int> cmults = {3, 2, 2, 2, 3};
+    const std::vector<double> cweights = {1, w, 1, w, 1, w, 1, w, 1};
+
+    // 1) Unit: a reversed (.F.) closed edge must discretize with the OPPOSITE winding.
+    auto c0 = std::make_shared<BSplineCurve>(2, circle_cps(0.0), cknots, cmults, cweights, true);
+    OrientedEdgeN fwd;
+    fwd.geometry = c0;
+    fwd.has_params = false;
+    fwd.same_sense = true;
+    fwd.orientation = true;
+    fwd.start = fwd.end = fwd.e_start = fwd.e_end = Vec3{r, 0, 0};
+    OrientedEdgeN rev = fwd;
+    rev.orientation = false;
+    auto signed_area_z = [](const std::vector<Vec3> &p) {
+        double a = 0;
+        for (size_t i = 0; i + 1 < p.size(); ++i) a += p[i].x * p[i + 1].y - p[i + 1].x * p[i].y;
+        return 0.5 * a;
+    };
+    auto pf = fwd.discretize(0.5, 0.349);
+    auto pr = rev.discretize(0.5, 0.349);
+    CHECK(pf.size() >= 8 && pr.size() >= 8, "closed B-spline edge discretizes densely");
+    CHECK(signed_area_z(pf) > 0.5 * 3.14159 * r * r,
+          "forward closed B-spline edge winds the curve's natural (CCW) way");
+    CHECK(signed_area_z(pr) < -0.5 * 3.14159 * r * r,
+          "ORIENTED_EDGE .F. reverses a closed B-spline edge (direction from flags, not endpoints)");
+
+    // 2) Face: the full tube (seam .F. + circle@0 .T. + seam .T. + circle@h .F. — the P400/Arestor
+    //    topology) must tessellate with ~the analytic lateral area, not drop.
+    auto surf = std::make_shared<BSplineSurface>();
+    surf->u_degree = 2;
+    surf->v_degree = 1;
+    surf->nu = 9;
+    surf->nv = 2;
+    surf->u_closed = true;
+    for (const Vec3 &p : circle_cps(0.0)) {
+        surf->ctrl.push_back(p);             // iv=0
+        surf->ctrl.push_back({p.x, p.y, h}); // iv=1
+    }
+    for (double wi : cweights) {
+        surf->weights.push_back(wi);
+        surf->weights.push_back(wi);
+    }
+    surf->Uu = {0, 0, 0, 0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1, 1, 1};
+    surf->Uv = {0, 0, 1, 1};
+
+    auto ch = std::make_shared<BSplineCurve>(2, circle_cps(h), cknots, cmults, cweights, true);
+    OrientedEdgeN seam; // LINE -> null geometry: straight through the endpoints
+    seam.geometry = nullptr;
+    seam.same_sense = true;
+    seam.orientation = true;
+    seam.e_start = Vec3{r, 0, 0};
+    seam.e_end = Vec3{r, 0, h};
+    seam.start = seam.e_start;
+    seam.end = seam.e_end;
+    OrientedEdgeN seam_rev = seam;
+    seam_rev.orientation = false;
+    seam_rev.start = seam.e_end;
+    seam_rev.end = seam.e_start;
+    OrientedEdgeN circ0 = fwd; // closed circle at z=0, forward
+    OrientedEdgeN circh;       // closed circle at z=h, REVERSED
+    circh.geometry = ch;
+    circh.has_params = false;
+    circh.same_sense = true;
+    circh.orientation = false;
+    circh.start = circh.end = circh.e_start = circh.e_end = Vec3{r, 0, h};
+
+    auto lp = std::make_shared<LoopN>();
+    lp->edges = {seam_rev, circ0, seam, circh};
+    FaceSurfaceN face;
+    face.surface = surf;
+    face.same_sense = true;
+    face.bounds.push_back({lp, true});
+
+    TessParams tp;
+    tp.deflection = 0.5;
+    tp.max_angle = 0.175;
+    TessMesh m;
+    bool ok = tessellate_face(face, tp, m);
+    CHECK(ok && m.indices.size() >= 3, "closed NURBS tube face tessellates (was dropped at |w|=2)");
+    double area = total_area(m);
+    double expect = 2.0 * 3.14159265358979 * r * h;
+    CHECK(close(area, expect, 0.05 * expect), "closed NURBS tube area ~ 2*pi*r*h");
+}
+
 int main() {
+    test_closed_bspline_edge_reversal_and_tube();
     test_plane_square_with_hole();
     test_plane_same_sense_false_flips_normal();
     test_cylinder_patch();

--- a/tests/py/test_ngeom_blob_emit.py
+++ b/tests/py/test_ngeom_blob_emit.py
@@ -1,0 +1,248 @@
+"""NGEOM-blob record streams -> STEP / IFC (stream_ngeom_to_step / stream_ngeom_to_ifc).
+
+The ada-object-model export fast path: Python serializes each object's geometry to an NGEOM
+blob and hands (name, blob, color, transforms, paths) records to the native emitters, replacing
+the per-entity Python writers. Blobs here are produced by the sibling binding StepNgeomStream
+(the same NGEOM wire the adapy serializer speaks), so the tests are self-contained: synthetic
+cube STEP -> per-solid blobs -> records -> emit -> read back through the native readers.
+"""
+
+import pytest
+
+cad = pytest.importorskip("adacpp.cad")
+
+_HEADER = """ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('synthetic cubes'),'2;1');
+FILE_NAME('','',(''),(''),'test','','');
+FILE_SCHEMA(('AP242_MANAGED_MODEL_BASED_3D_ENGINEERING_MIM_LF { 1 0 10303 442 1 1 4 }'));
+ENDSEC;
+DATA;
+#1=APPLICATION_CONTEXT('managed model based 3d engineering');
+#2=APPLICATION_PROTOCOL_DEFINITION('international standard','ap242_managed_model_based_3d_engineering_mim_lf',2014,#1);
+#3=PRODUCT_CONTEXT('',#1,'mechanical');
+#4=PRODUCT_DEFINITION_CONTEXT('part definition',#1,'design');
+#5=(LENGTH_UNIT()NAMED_UNIT(*)SI_UNIT($,.METRE.));
+#6=(NAMED_UNIT(*)PLANE_ANGLE_UNIT()SI_UNIT($,.RADIAN.));
+#7=(NAMED_UNIT(*)SI_UNIT($,.STERADIAN.)SOLID_ANGLE_UNIT());
+#8=UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(1.E-6),#5,'distance_accuracy_value','edge/vertex');
+#9=(GEOMETRIC_REPRESENTATION_CONTEXT(3)GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT((#8))GLOBAL_UNIT_ASSIGNED_CONTEXT((#5,#6,#7))REPRESENTATION_CONTEXT('Context','3D'));
+#10=CARTESIAN_POINT('',(0.,0.,0.));
+#11=DIRECTION('',(0.,0.,1.));
+#12=DIRECTION('',(1.,0.,0.));
+#13=AXIS2_PLACEMENT_3D('',#10,#11,#12);
+"""
+
+
+def _fmt(v):
+    return f"{v:.6f}"
+
+
+class _Spf:
+    def __init__(self):
+        self.lines = []
+        self.nid = 13
+
+    def emit(self, body):
+        self.nid += 1
+        self.lines.append(f"#{self.nid}={body};")
+        return self.nid
+
+    def pt(self, p):
+        return self.emit(f"CARTESIAN_POINT('',({_fmt(p[0])},{_fmt(p[1])},{_fmt(p[2])}))")
+
+    def dirn(self, d):
+        return self.emit(f"DIRECTION('',({_fmt(d[0])},{_fmt(d[1])},{_fmt(d[2])}))")
+
+    def axis2(self, loc, z, x):
+        return self.emit(f"AXIS2_PLACEMENT_3D('',#{self.pt(loc)},#{self.dirn(z)},#{self.dirn(x)})")
+
+    def plane_face(self, poly, normal, xdir):
+        plane = self.emit(f"PLANE('',#{self.axis2(poly[0], normal, xdir)})")
+        pids = [self.pt(p) for p in poly]
+        loop = self.emit("POLY_LOOP('',({}))".format(",".join(f"#{i}" for i in pids)))
+        bound = self.emit(f"FACE_OUTER_BOUND('',#{loop},.T.)")
+        return self.emit(f"ADVANCED_FACE('',(#{bound}),#{plane},.T.)")
+
+    def cube(self, name, origin=(0.0, 0.0, 0.0)):
+        ox, oy, oz = origin
+        c = [
+            ([(0, 0, 0), (0, 1, 0), (1, 1, 0), (1, 0, 0)], (0, 0, -1), (1, 0, 0)),
+            ([(0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1)], (0, 0, 1), (1, 0, 0)),
+            ([(0, 0, 0), (0, 0, 1), (0, 1, 1), (0, 1, 0)], (-1, 0, 0), (0, 1, 0)),
+            ([(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)], (1, 0, 0), (0, 1, 0)),
+            ([(0, 0, 0), (1, 0, 0), (1, 0, 1), (0, 0, 1)], (0, -1, 0), (1, 0, 0)),
+            ([(0, 1, 0), (0, 1, 1), (1, 1, 1), (1, 1, 0)], (0, 1, 0), (1, 0, 0)),
+        ]
+        fids = [
+            self.plane_face([(p[0] + ox, p[1] + oy, p[2] + oz) for p in poly], n, xd) for poly, n, xd in c
+        ]
+        shell = self.emit("CLOSED_SHELL('',({}))".format(",".join(f"#{i}" for i in fids)))
+        brep = self.emit(f"MANIFOLD_SOLID_BREP('{name}',#{shell})")
+        absr = self.emit(f"ADVANCED_BREP_SHAPE_REPRESENTATION('{name}',(#13,#{brep}),#9)")
+        prod = self.emit(f"PRODUCT('{name}','{name}','',(#3))")
+        pdf = self.emit(f"PRODUCT_DEFINITION_FORMATION('','',#{prod})")
+        pd = self.emit(f"PRODUCT_DEFINITION('design','',#{pdf},#4)")
+        pds = self.emit(f"PRODUCT_DEFINITION_SHAPE('','',#{pd})")
+        self.emit(f"SHAPE_DEFINITION_REPRESENTATION(#{pds},#{absr})")
+
+
+def _two_cube_step() -> str:
+    w = _Spf()
+    w.cube("cube_a")
+    w.cube("cube_b", origin=(3.0, 0.0, 0.0))
+    return _HEADER + "\n".join(w.lines) + "\nENDSEC;\nEND-ISO-10303-21;\n"
+
+
+# Two rigid placements for the instancing tests: identity and +5x.
+_T_IDENT = [1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0, 0, 0.0, 0.0, 0.0, 1.0]
+_T_SHIFT = [1.0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 1.0, 0, 5.0, 0.0, 0.0, 1.0]
+
+_RED = (1.0, 0.0, 0.0, 1.0)
+
+
+@pytest.fixture()
+def blobs(tmp_path):
+    """Per-solid NGEOM blobs for the two cubes (via the native STEP->NGEOM stream)."""
+    p = tmp_path / "cubes.stp"
+    p.write_text(_two_cube_step())
+    out = [(bytes(b), m) for b, m in cad.StepNgeomStream(str(p))]
+    assert len(out) == 2
+    return out
+
+
+def _records(blobs, color=None, paths=None):
+    return [
+        (m.id or f"solid_{i}", b, color, None, paths[i] if paths else None)
+        for i, (b, m) in enumerate(blobs)
+    ]
+
+
+def test_step_flat_records(blobs, tmp_path):
+    out = tmp_path / "out.stp"
+    st = cad.stream_ngeom_to_step(_records(blobs, color=_RED), str(out))
+    assert st["solids_in"] == 2
+    assert st["solids_out"] == 2
+    assert st["instances_out"] == 2
+    assert st["faces_dropped"] == 0
+    data = out.read_text()
+    assert "AP242_MANAGED_MODEL_BASED_3D_ENGINEERING" in data
+    assert "SI_UNIT($,.METRE.)" in data
+    assert data.count("CLOSED_SHELL") == 2
+    assert data.count("MANIFOLD_SOLID_BREP") == 2
+    # presentation colour: one STYLED_ITEM chain per solid + the single trailer
+    assert data.count("STYLED_ITEM") == 2
+    assert data.count("COLOUR_RGB('',1.,0.,0.)") == 2
+    assert data.count("MECHANICAL_DESIGN_GEOMETRIC_PRESENTATION_REPRESENTATION") == 1
+    # read-back through the native stream reader: 2 roots, names preserved
+    roots = [(bytes(b), m) for b, m in cad.StepNgeomStream(str(out))]
+    assert len(roots) == 2
+    assert sorted(m.id for _b, m in roots) == ["cube_a", "cube_b"]
+
+
+def test_step_assembly_paths(blobs, tmp_path):
+    out = tmp_path / "tree.stp"
+    paths = [
+        [[(1, "deck"), (10, "cube_a")]],
+        [[(1, "deck"), (11, "cube_b")]],
+    ]
+    st = cad.stream_ngeom_to_step(_records(blobs, paths=paths), str(out))
+    assert st["solids_out"] == 2
+    data = out.read_text()
+    # ONE shared assembly node 'deck', both leaves hung off it via NAUO
+    assert data.count("PRODUCT('deck'") == 1
+    assert data.count("NEXT_ASSEMBLY_USAGE_OCCURRENCE") == 2
+
+
+def test_step_mapped_instances_from_records(blobs, tmp_path):
+    out = tmp_path / "mapped.stp"
+    b, m = blobs[0]
+    st = cad.stream_ngeom_to_step([("box", b, None, [_T_IDENT, _T_SHIFT], None)], str(out))
+    assert st["solids_in"] == 1
+    assert st["solids_out"] == 1
+    assert st["instances_out"] == 2
+    data = out.read_text()
+    assert data.count("MANIFOLD_SOLID_BREP") == 1, "prototype must be serialised exactly once"
+    assert data.count("NEXT_ASSEMBLY_USAGE_OCCURRENCE") == 2
+    assert data.count("CONTEXT_DEPENDENT_SHAPE_REPRESENTATION") == 2
+    assert data.count("SHAPE_REPRESENTATION('model'") == 1
+    # read-back: one root, both placements recovered
+    roots = [(bytes(bb), mm) for bb, mm in cad.StepNgeomStream(str(out))]
+    assert len(roots) == 1
+    tr = sorted(tuple(round(t[i], 4) for i in (12, 13, 14)) for t in roots[0][1].transforms)
+    assert tr == [(0.0, 0.0, 0.0), (5.0, 0.0, 0.0)]
+
+
+def test_ifc_flat_records(blobs, tmp_path):
+    out = tmp_path / "out.ifc"
+    st = cad.stream_ngeom_to_ifc(_records(blobs, color=_RED), str(out))
+    assert st["solids_in"] == 2
+    assert st["solids_out"] == 2
+    assert st["instances_out"] == 2
+    assert st["faces_dropped"] == 0
+    data = out.read_text()
+    assert "FILE_SCHEMA(('IFC4X3_ADD2'))" in data
+    assert "IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.)" in data
+    assert data.count("IFCCLOSEDSHELL") == 2 or data.count("IfcClosedShell") == 2
+    assert data.count("IfcBuildingElementProxy") == 2
+    assert data.count("IfcStyledItem") == 2
+    assert data.count("IfcColourRgb") == 2
+    # read-back through the native IFC->NGEOM stream: both products, none skipped
+    s = cad.IfcNgeomStream(str(out))
+    roots = [(bytes(b), m) for b, m in s]
+    assert len(roots) == 2
+    assert s.products_skipped == 0
+
+
+def test_ifc_spatial_tree_and_mapped(blobs, tmp_path):
+    out = tmp_path / "tree.ifc"
+    b, m = blobs[0]
+    st = cad.stream_ngeom_to_ifc(
+        [("box", b, None, [_T_IDENT, _T_SHIFT], [[(1, "deck"), (10, "box")], [(1, "deck"), (10, "box")]])],
+        str(out),
+    )
+    assert st["solids_in"] == 1
+    assert st["instances_out"] == 2
+    data = out.read_text()
+    assert data.count("IfcMappedItem") == 2, "instances must share geometry via IfcMappedItem"
+    assert data.count("IfcRepresentationMap") == 1
+    assert data.count("IFCSPATIALZONE('") >= 1  # 'deck' zone (root zone is in the header block)
+    assert "deck" in data
+
+
+def test_ifc_parses_with_ifcopenshell(blobs, tmp_path):
+    ifcopenshell = pytest.importorskip("ifcopenshell")
+    out = tmp_path / "check.ifc"
+    cad.stream_ngeom_to_ifc(_records(blobs, color=_RED), str(out))
+    f = ifcopenshell.open(str(out))
+    assert len(f.by_type("IfcBuildingElementProxy")) == 2
+    assert len(f.by_type("IfcClosedShell")) == 2
+
+
+def test_generator_records_stream(blobs, tmp_path):
+    """Records may come from a generator (lazy pull) and must match the one-shot list output."""
+    out_list = tmp_path / "list.stp"
+    out_gen = tmp_path / "gen.stp"
+    recs = _records(blobs, color=_RED)
+    cad.stream_ngeom_to_step(recs, str(out_list))
+    cad.stream_ngeom_to_step((r for r in recs), str(out_gen))
+    assert out_gen.read_bytes() == out_list.read_bytes()
+
+
+def test_unit_scale_header(blobs, tmp_path):
+    out_s = tmp_path / "mm.stp"
+    out_i = tmp_path / "mm.ifc"
+    cad.stream_ngeom_to_step(_records(blobs), str(out_s), unit_scale=0.001)
+    cad.stream_ngeom_to_ifc(_records(blobs), str(out_i), unit_scale=0.001)
+    assert "SI_UNIT(.MILLI.,.METRE.)" in out_s.read_text()
+    assert "IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.)" in out_i.read_text()
+
+
+def test_short_records_and_name_override(blobs, tmp_path):
+    """2-tuples work; a non-empty record name overrides the blob's root id."""
+    out = tmp_path / "short.stp"
+    b, _m = blobs[0]
+    st = cad.stream_ngeom_to_step([("renamed_cube", b)], str(out))
+    assert st["solids_out"] == 1
+    roots = [(bytes(bb), mm) for bb, mm in cad.StepNgeomStream(str(out))]
+    assert roots[0][1].id == "renamed_cube"

--- a/tests/py/test_ngeom_blob_emit.py
+++ b/tests/py/test_ngeom_blob_emit.py
@@ -149,9 +149,14 @@ def test_step_assembly_paths(blobs, tmp_path):
     st = cad.stream_ngeom_to_step(_records(blobs, paths=paths), str(out))
     assert st["solids_out"] == 2
     data = out.read_text()
-    # ONE shared assembly node 'deck', both leaves hung off it via NAUO
+    # ONE shared assembly node 'deck' (with its own empty SHAPE_REPRESENTATION), both leaves
+    # hung off it via the FULL occurrence record (NAUO + identity IDT + complex-RR + CDSR) —
+    # the pattern OCC's reader needs to find geometry under the shapeless assembly product.
     assert data.count("PRODUCT('deck'") == 1
+    assert data.count("SHAPE_REPRESENTATION('deck'") == 1
     assert data.count("NEXT_ASSEMBLY_USAGE_OCCURRENCE") == 2
+    assert data.count("CONTEXT_DEPENDENT_SHAPE_REPRESENTATION") == 2
+    assert data.count("ITEM_DEFINED_TRANSFORMATION") == 2
 
 
 def test_step_mapped_instances_from_records(blobs, tmp_path):

--- a/tests/py/test_ngeom_blob_emit.py
+++ b/tests/py/test_ngeom_blob_emit.py
@@ -243,6 +243,72 @@ def test_unit_scale_header(blobs, tmp_path):
     assert "IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.)" in out_i.read_text()
 
 
+_IFC_SHELL_HEADER = """ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('','',(''),(''),'test','','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCCARTESIANPOINT((0.,0.,0.));
+#2=IFCDIRECTION((0.,0.,1.));
+#3=IFCDIRECTION((1.,0.,0.));
+#4=IFCAXIS2PLACEMENT3D(#1,#2,#3);
+#5=IFCDIRECTION((1.,0.));
+#6=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,#5);
+#7=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#8=IFCUNITASSIGNMENT((#7));
+#9=IFCPROJECT('0aaaaaaaaaaaaaaaaaaaaa',$,'frag test',$,$,$,$,(#6),#8);
+#10=IFCAXIS2PLACEMENT3D(#1,$,$);
+#11=IFCLOCALPLACEMENT($,#10);
+"""
+
+
+def test_ifc_body_spf_fragment(blobs, tmp_path):
+    """The body-fragment binding: geometry-only SPF, contiguous ids from first_id, and the
+    returned body item id is the brep a hand-built typed wrapper can reference."""
+    b, m = blobs[0]
+    spf, next_id, body, rep_type = cad.ngeom_to_ifc_body_spf(b, 100)
+    assert body >= 100
+    assert rep_type == "AdvancedBrep"
+    ids = [int(ln.split("=")[0][1:]) for ln in spf.strip().splitlines()]
+    assert ids[0] == 100, "entity numbering must start at first_id"
+    assert ids == sorted(ids) and ids[-1] == next_id - 1, "ids must be contiguous from first_id"
+    assert body in ids
+    # fragment is geometry-only: no header/product/spatial/style entities
+    for kw in ("IfcProject", "IfcShapeRepresentation", "IfcBuildingElementProxy", "IfcStyledItem"):
+        assert kw not in spf
+    assert "IfcAdvancedBrep" in spf
+
+    # splice into a minimal hand-built SPF shell with a typed wrapper -> ifcopenshell parses it
+    ifcopenshell = pytest.importorskip("ifcopenshell")
+    wrap = (
+        f"#{next_id}=IFCSHAPEREPRESENTATION(#6,'Body','{rep_type}',(#{body}));\n"
+        f"#{next_id + 1}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{next_id}));\n"
+        f"#{next_id + 2}=IFCPLATE('1aaaaaaaaaaaaaaaaaaaaa',$,'frag_plate',$,$,#11,#{next_id + 1},$,$);\n"
+    )
+    out = tmp_path / "frag.ifc"
+    out.write_text(_IFC_SHELL_HEADER + spf + wrap + "ENDSEC;\nEND-ISO-10303-21;\n")
+    f = ifcopenshell.open(str(out))
+    (plate,) = f.by_type("IfcPlate")
+    (rep,) = plate.Representation.Representations
+    assert rep.RepresentationType == "AdvancedBrep"
+    assert rep.Items[0].id() == body, "wrapper must reference the returned brep item id"
+    assert rep.Items[0].is_a("IfcAdvancedBrep")
+    assert len(rep.Items[0].Outer.CfsFaces) == 6
+
+
+def test_ifc_body_spf_single_root_contract(tmp_path):
+    """A multi-root blob is rejected (the adapy writer serializes one solid per blob)."""
+    p = tmp_path / "cubes.stp"
+    p.write_text(_two_cube_step())
+    # stream_step_to_ngeom yields ONE buffer holding both roots
+    buf, metas = cad.stream_step_to_ngeom(str(p))
+    assert len(metas) == 2
+    with pytest.raises(RuntimeError, match="exactly one root"):
+        cad.ngeom_to_ifc_body_spf(bytes(buf), 100)
+
+
 def test_short_records_and_name_override(blobs, tmp_path):
     """2-tuples work; a non-empty record name overrides the blob's root id."""
     out = tmp_path / "short.stp"

--- a/tests/py/test_ngeom_blob_emit.py
+++ b/tests/py/test_ngeom_blob_emit.py
@@ -74,9 +74,7 @@ class _Spf:
             ([(0, 0, 0), (1, 0, 0), (1, 0, 1), (0, 0, 1)], (0, -1, 0), (1, 0, 0)),
             ([(0, 1, 0), (0, 1, 1), (1, 1, 1), (1, 1, 0)], (0, 1, 0), (1, 0, 0)),
         ]
-        fids = [
-            self.plane_face([(p[0] + ox, p[1] + oy, p[2] + oz) for p in poly], n, xd) for poly, n, xd in c
-        ]
+        fids = [self.plane_face([(p[0] + ox, p[1] + oy, p[2] + oz) for p in poly], n, xd) for poly, n, xd in c]
         shell = self.emit("CLOSED_SHELL('',({}))".format(",".join(f"#{i}" for i in fids)))
         brep = self.emit(f"MANIFOLD_SOLID_BREP('{name}',#{shell})")
         absr = self.emit(f"ADVANCED_BREP_SHAPE_REPRESENTATION('{name}',(#13,#{brep}),#9)")
@@ -112,10 +110,7 @@ def blobs(tmp_path):
 
 
 def _records(blobs, color=None, paths=None):
-    return [
-        (m.id or f"solid_{i}", b, color, None, paths[i] if paths else None)
-        for i, (b, m) in enumerate(blobs)
-    ]
+    return [(m.id or f"solid_{i}", b, color, None, paths[i] if paths else None) for i, (b, m) in enumerate(blobs)]
 
 
 def test_step_flat_records(blobs, tmp_path):

--- a/tests/py/test_ngeom_mesh_emit.py
+++ b/tests/py/test_ngeom_mesh_emit.py
@@ -1,0 +1,199 @@
+"""NGEOM-blob record streams -> GLB / OBJ / STL (stream_ngeom_to_glb / stream_ngeom_to_mesh).
+
+The ada-object-model MESH export fast path: same record front-end as stream_ngeom_to_step/ifc,
+back half of the native STEP->GLB / STEP->mesh tessellate+emit cores. Blobs are produced by the
+sibling binding StepNgeomStream from synthetic cube STEP (see test_ngeom_blob_emit), so the tests
+are self-contained and the step-source native converters double as the oracle: the records path
+must produce the same triangle/vertex counts as stream_step_to_glb / stream_step_to_mesh on the
+same file.
+"""
+
+import json
+import pathlib
+import struct
+
+import pytest
+
+cad = pytest.importorskip("adacpp.cad")
+
+from test_ngeom_blob_emit import _RED, _T_IDENT, _T_SHIFT, _records, _two_cube_step  # noqa: E402
+
+
+@pytest.fixture()
+def step_path(tmp_path):
+    p = tmp_path / "cubes.stp"
+    p.write_text(_two_cube_step())
+    return p
+
+
+@pytest.fixture()
+def blobs(step_path):
+    out = [(bytes(b), m) for b, m in cad.StepNgeomStream(str(step_path))]
+    assert len(out) == 2
+    return out
+
+
+def _glb_json(path) -> dict:
+    data = pathlib.Path(path).read_bytes()
+    assert data[:4] == b"glTF", "not a GLB container"
+    (json_len, json_type) = struct.unpack_from("<II", data, 12)
+    assert json_type == 0x4E4F534A  # 'JSON'
+    return json.loads(data[20 : 20 + json_len])
+
+
+def _glb_counts(path) -> tuple[int, int]:
+    """(triangles, vertices) summed over every primitive, from the accessor headers (valid for
+    raw and meshopt-compressed GLBs alike — EXT_meshopt only re-encodes the buffer bytes)."""
+    j = _glb_json(path)
+    acc = j["accessors"]
+    tris = verts = 0
+    for mesh in j.get("meshes", []):
+        for prim in mesh["primitives"]:
+            tris += acc[prim["indices"]]["count"] // 3
+            verts += acc[prim["attributes"]["POSITION"]]["count"]
+    return tris, verts
+
+
+def _stl_tris(path) -> int:
+    data = pathlib.Path(path).read_bytes()
+    return struct.unpack_from("<I", data, 80)[0]
+
+
+def _obj_counts(path) -> tuple[int, int]:
+    v = f = 0
+    with open(path) as fh:
+        for line in fh:
+            if line.startswith("v "):
+                v += 1
+            elif line.startswith("f "):
+                f += 1
+    return f, v
+
+
+# ---------------------------------------------------------------------------------------------
+# GLB
+
+
+def test_glb_records_match_step_native(blobs, step_path, tmp_path):
+    """Records -> GLB carries exactly the geometry the step-source native converter produces."""
+    ref = tmp_path / "ref.glb"
+    n = cad.stream_step_to_glb(str(step_path), str(ref))
+    assert n == 2
+    out = tmp_path / "out.glb"
+    st = cad.stream_ngeom_to_glb(_records(blobs), str(out))
+    assert st["solids_in"] == 2
+    assert st["solids_out"] == 2
+    assert st["solids_skipped"] == 0
+    assert st["instances_out"] == 2
+    assert st["faces_dropped"] == 0
+    assert _glb_counts(out) == _glb_counts(ref)
+    assert st["triangles"] == _glb_counts(out)[0]
+    # per-solid draw ranges carry the record names (picking)
+    raw = out.read_bytes()
+    assert b"cube_a" in raw and b"cube_b" in raw
+
+
+def test_glb_records_colour(blobs, tmp_path):
+    out = tmp_path / "red.glb"
+    cad.stream_ngeom_to_glb(_records(blobs, color=_RED), str(out))
+    j = _glb_json(out)
+    cols = [m["pbrMetallicRoughness"]["baseColorFactor"] for m in j["materials"]]
+    assert len(cols) == 1, "same colour must merge into one material"
+    r, g, b, a = cols[0]
+    assert (round(r, 4), round(g, 4), round(b, 4), a) == (1.0, 0.0, 0.0, 1.0)
+
+
+def test_glb_records_instances(blobs, tmp_path):
+    b, _m = blobs[0]
+    out = tmp_path / "inst.glb"
+    st = cad.stream_ngeom_to_glb([("box", b, None, [_T_IDENT, _T_SHIFT], None)], str(out))
+    assert st["solids_in"] == 1
+    assert st["instances_out"] == 2
+    tris, _verts = _glb_counts(out)
+    assert tris == st["triangles"] == 2 * 12  # both placements baked (12 tris per cube)
+
+
+def test_glb_records_unit_scale(blobs, tmp_path):
+    """unit_scale converts model units to metres: a mm-model cube becomes 0.001 m."""
+    out_m = tmp_path / "m.glb"
+    out_mm = tmp_path / "mm.glb"
+    cad.stream_ngeom_to_glb(_records(blobs), str(out_m))
+    cad.stream_ngeom_to_glb(_records(blobs), str(out_mm), unit_scale=0.001)
+
+    def _pos_max(path):
+        j = _glb_json(path)
+        acc = j["accessors"]
+        return max(max(acc[p["attributes"]["POSITION"]]["max"]) for m in j["meshes"] for p in m["primitives"])
+
+    hi_m = _pos_max(out_m)
+    hi_mm = _pos_max(out_mm)
+    assert hi_m == pytest.approx(4.0)  # cube_b spans x in [3, 4]
+    assert hi_mm == pytest.approx(0.004)
+
+
+def test_glb_generator_and_thread_count_deterministic(blobs, tmp_path):
+    """Generator input and any thread count must produce byte-identical output (ordered commits)."""
+    recs = _records(blobs, color=_RED)
+    a = tmp_path / "a.glb"
+    b = tmp_path / "b.glb"
+    c = tmp_path / "c.glb"
+    cad.stream_ngeom_to_glb(recs, str(a))
+    cad.stream_ngeom_to_glb((r for r in recs), str(b))
+    cad.stream_ngeom_to_glb(recs, str(c), num_threads=1)
+    assert a.read_bytes() == b.read_bytes() == c.read_bytes()
+
+
+def test_glb_unknown_pipeline_raises(blobs, tmp_path):
+    with pytest.raises(RuntimeError, match="pipeline"):
+        cad.stream_ngeom_to_glb(_records(blobs), str(tmp_path / "x.glb"), pipeline="no-such-track")
+
+
+# ---------------------------------------------------------------------------------------------
+# OBJ / STL
+
+
+@pytest.mark.parametrize("fmt", ["obj", "stl"])
+def test_mesh_records_match_step_native(blobs, step_path, tmp_path, fmt):
+    """Records -> OBJ/STL triangle+vertex counts equal the step-source native converter's."""
+    ref = tmp_path / f"ref.{fmt}"
+    ref_tris = cad.stream_step_to_mesh(str(step_path), str(ref), fmt)
+    out = tmp_path / f"out.{fmt}"
+    st = cad.stream_ngeom_to_mesh(_records(blobs), str(out), fmt)
+    assert st["solids_in"] == 2
+    assert st["solids_out"] == 2
+    assert st["faces_dropped"] == 0
+    assert st["triangles"] == ref_tris
+    if fmt == "stl":
+        assert _stl_tris(out) == _stl_tris(ref) == ref_tris
+    else:
+        assert _obj_counts(out) == _obj_counts(ref)
+        assert _obj_counts(out)[0] == ref_tris
+
+
+def test_mesh_records_instances_and_unit_scale(blobs, tmp_path):
+    b, _m = blobs[0]
+    out = tmp_path / "inst.stl"
+    st = cad.stream_ngeom_to_mesh([("box", b, None, [_T_IDENT, _T_SHIFT], None)], str(out), "stl", unit_scale=0.001)
+    assert st["instances_out"] == 2
+    assert _stl_tris(out) == st["triangles"] == 2 * 12
+    # unit_scale + the +5x shifted instance both baked: max x ~= (1 + 5) * 0.001
+    data = out.read_bytes()
+    xs = [struct.unpack_from("<f", data, 84 + 50 * i + 12)[0] for i in range(_stl_tris(out))]
+    assert max(xs) <= 0.006 + 1e-6
+    assert max(xs) > 0.004
+
+
+def test_mesh_generator_and_thread_count_deterministic(blobs, tmp_path):
+    recs = _records(blobs)
+    a = tmp_path / "a.obj"
+    b = tmp_path / "b.obj"
+    c = tmp_path / "c.obj"
+    cad.stream_ngeom_to_mesh(recs, str(a), "obj")
+    cad.stream_ngeom_to_mesh((r for r in recs), str(b), "obj")
+    cad.stream_ngeom_to_mesh(recs, str(c), "obj", num_threads=1)
+    assert a.read_bytes() == b.read_bytes() == c.read_bytes()
+
+
+def test_mesh_bad_fmt_raises(blobs, tmp_path):
+    with pytest.raises(RuntimeError, match="fmt"):
+        cad.stream_ngeom_to_mesh(_records(blobs), str(tmp_path / "x.ply"), "ply")

--- a/tests/py/test_step_mapped_instances.py
+++ b/tests/py/test_step_mapped_instances.py
@@ -1,0 +1,241 @@
+"""STEP->STEP mapped (shared-prototype) instancing.
+
+A solid placed N>1 times must be serialised ONCE as a prototype B-rep and referenced per
+placement through the AP242 assembly-instancing pattern (NAUO + CONTEXT_DEPENDENT_SHAPE_
+REPRESENTATION + ITEM_DEFINED_TRANSFORMATION) — the exact pattern the native stream readers
+(C++ Resolver and adapy's pure-Python stream reader) already parse. The source here is a
+hand-authored cube placed 3 times (identity, translation, rotation+translation) using that
+same pattern, so the test covers the full read->write->read round trip.
+
+ADACPP_STEP_BAKE_INSTANCES=1 must restore the old all-baked form (one full B-rep per
+placement, no assembly records).
+"""
+
+import math
+
+import pytest
+
+cad = pytest.importorskip("adacpp.cad")
+
+_HEADER = """ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('synthetic mapped-instance cube'),'2;1');
+FILE_NAME('','',(''),(''),'test','','');
+FILE_SCHEMA(('AP242_MANAGED_MODEL_BASED_3D_ENGINEERING_MIM_LF { 1 0 10303 442 1 1 4 }'));
+ENDSEC;
+DATA;
+#1=APPLICATION_CONTEXT('managed model based 3d engineering');
+#2=APPLICATION_PROTOCOL_DEFINITION('international standard','ap242_managed_model_based_3d_engineering_mim_lf',2014,#1);
+#3=PRODUCT_CONTEXT('',#1,'mechanical');
+#4=PRODUCT_DEFINITION_CONTEXT('part definition',#1,'design');
+#5=(LENGTH_UNIT()NAMED_UNIT(*)SI_UNIT($,.METRE.));
+#6=(NAMED_UNIT(*)PLANE_ANGLE_UNIT()SI_UNIT($,.RADIAN.));
+#7=(NAMED_UNIT(*)SI_UNIT($,.STERADIAN.)SOLID_ANGLE_UNIT());
+#8=UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(1.E-6),#5,'distance_accuracy_value','edge/vertex');
+#9=(GEOMETRIC_REPRESENTATION_CONTEXT(3)GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT((#8))GLOBAL_UNIT_ASSIGNED_CONTEXT((#5,#6,#7))REPRESENTATION_CONTEXT('Context','3D'));
+#10=CARTESIAN_POINT('',(0.,0.,0.));
+#11=DIRECTION('',(0.,0.,1.));
+#12=DIRECTION('',(1.,0.,0.));
+#13=AXIS2_PLACEMENT_3D('',#10,#11,#12);
+"""
+
+# The three world placements: identity, +2x translation, and 90 deg about z at (0,3,0).
+# (loc, z_axis, x_ref) — AXIS2_PLACEMENT_3D form.
+_PLACEMENTS = [
+    ((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0)),
+    ((2.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0)),
+    ((0.0, 3.0, 0.0), (0.0, 0.0, 1.0), (0.0, 1.0, 0.0)),
+]
+
+
+def _fmt(v):
+    return f"{v:.6f}"
+
+
+class _Spf:
+    def __init__(self):
+        self.lines = []
+        self.nid = 13  # continue after the fixed header block
+
+    def emit(self, body):
+        self.nid += 1
+        self.lines.append(f"#{self.nid}={body};")
+        return self.nid
+
+    def pt(self, p):
+        return self.emit(f"CARTESIAN_POINT('',({_fmt(p[0])},{_fmt(p[1])},{_fmt(p[2])}))")
+
+    def dirn(self, d):
+        return self.emit(f"DIRECTION('',({_fmt(d[0])},{_fmt(d[1])},{_fmt(d[2])}))")
+
+    def axis2(self, loc, z, x):
+        return self.emit(f"AXIS2_PLACEMENT_3D('',#{self.pt(loc)},#{self.dirn(z)},#{self.dirn(x)})")
+
+    def plane_face(self, poly, normal, xdir):
+        plane = self.emit(f"PLANE('',#{self.axis2(poly[0], normal, xdir)})")
+        pids = [self.pt(p) for p in poly]
+        loop = self.emit("POLY_LOOP('',({}))".format(",".join(f"#{i}" for i in pids)))
+        bound = self.emit(f"FACE_OUTER_BOUND('',#{loop},.T.)")
+        return self.emit(f"ADVANCED_FACE('',(#{bound}),#{plane},.T.)")
+
+
+def _cube_instanced_step() -> str:
+    """One unit-cube MANIFOLD_SOLID_BREP prototype + 3 CDSR placements (the reader's pattern)."""
+    w = _Spf()
+    # 6 planar faces of the unit cube, outward normals (winding not load-bearing for this test).
+    c = [
+        ([(0, 0, 0), (0, 1, 0), (1, 1, 0), (1, 0, 0)], (0, 0, -1), (1, 0, 0)),  # bottom
+        ([(0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1)], (0, 0, 1), (1, 0, 0)),  # top
+        ([(0, 0, 0), (0, 0, 1), (0, 1, 1), (0, 1, 0)], (-1, 0, 0), (0, 1, 0)),  # -x
+        ([(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)], (1, 0, 0), (0, 1, 0)),  # +x
+        ([(0, 0, 0), (1, 0, 0), (1, 0, 1), (0, 0, 1)], (0, -1, 0), (1, 0, 0)),  # -y
+        ([(0, 1, 0), (0, 1, 1), (1, 1, 1), (1, 1, 0)], (0, 1, 0), (1, 0, 0)),  # +y
+    ]
+    fids = [w.plane_face([tuple(float(x) for x in p) for p in poly], n, xd) for poly, n, xd in c]
+    shell = w.emit("CLOSED_SHELL('',({}))".format(",".join(f"#{i}" for i in fids)))
+    brep = w.emit(f"MANIFOLD_SOLID_BREP('cube',#{shell})")
+    absr = w.emit(f"ADVANCED_BREP_SHAPE_REPRESENTATION('cube',(#13,#{brep}),#9)")
+    prod = w.emit("PRODUCT('cube','cube','',(#3))")
+    pdf = w.emit(f"PRODUCT_DEFINITION_FORMATION('','',#{prod})")
+    pd = w.emit(f"PRODUCT_DEFINITION('design','',#{pdf},#4)")
+    pds = w.emit(f"PRODUCT_DEFINITION_SHAPE('','',#{pd})")
+    w.emit(f"SHAPE_DEFINITION_REPRESENTATION(#{pds},#{absr})")
+    # Root assembly product + world rep.
+    rprod = w.emit("PRODUCT('model','model','',(#3))")
+    rpdf = w.emit(f"PRODUCT_DEFINITION_FORMATION('','',#{rprod})")
+    rpd = w.emit(f"PRODUCT_DEFINITION('design','',#{rpdf},#4)")
+    rpds = w.emit(f"PRODUCT_DEFINITION_SHAPE('','',#{rpd})")
+    axes = [w.axis2(loc, z, x) for loc, z, x in _PLACEMENTS]
+    wrep = w.emit("SHAPE_REPRESENTATION('model',(#13,{}),#9)".format(",".join(f"#{a}" for a in axes)))
+    w.emit(f"SHAPE_DEFINITION_REPRESENTATION(#{rpds},#{wrep})")
+    for k, axis in enumerate(axes):
+        idt = w.emit(f"ITEM_DEFINED_TRANSFORMATION('','',#13,#{axis})")
+        rr = w.emit(
+            f"(REPRESENTATION_RELATIONSHIP('','',#{absr},#{wrep})"
+            f"REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(#{idt})"
+            "SHAPE_REPRESENTATION_RELATIONSHIP())"
+        )
+        nauo = w.emit(f"NEXT_ASSEMBLY_USAGE_OCCURRENCE('i{k}','cube','',#{rpd},#{pd},$)")
+        npds = w.emit(f"PRODUCT_DEFINITION_SHAPE('','',#{nauo})")
+        w.emit(f"CONTEXT_DEPENDENT_SHAPE_REPRESENTATION(#{rr},#{npds})")
+    return _HEADER + "\n".join(w.lines) + "\nENDSEC;\nEND-ISO-10303-21;\n"
+
+
+def _roots(path):
+    return [(n, m) for n, m in cad.StepNgeomStream(str(path))]
+
+
+def _translations(meta):
+    return sorted(tuple(round(t[i], 4) for i in (12, 13, 14)) for t in meta.transforms)
+
+
+_EXPECT_TRANSLATIONS = sorted([(0.0, 0.0, 0.0), (2.0, 0.0, 0.0), (0.0, 3.0, 0.0)])
+
+
+@pytest.fixture()
+def src(tmp_path):
+    p = tmp_path / "cube_instanced.stp"
+    p.write_text(_cube_instanced_step())
+    return p
+
+
+def test_source_pattern_reads_as_three_instances(src):
+    roots = _roots(src)
+    assert len(roots) == 1
+    meta = roots[0][1]
+    assert len(meta.transforms) == 3
+    assert _translations(meta) == _EXPECT_TRANSLATIONS
+
+
+def test_step_to_step_emits_shared_prototype(src, tmp_path):
+    out = tmp_path / "mapped.stp"
+    st = cad.stream_step_to_step(str(src), str(out))
+    assert st["solids_in"] == 1
+    assert st["solids_out"] == 1
+    assert st["instances_out"] == 3
+    assert st["faces_dropped"] == 0
+
+    data = out.read_text()
+    assert data.count("MANIFOLD_SOLID_BREP") == 1, "prototype must be serialised exactly once"
+    assert data.count("NEXT_ASSEMBLY_USAGE_OCCURRENCE") == 3
+    assert data.count("CONTEXT_DEPENDENT_SHAPE_REPRESENTATION") == 3
+    assert data.count("ITEM_DEFINED_TRANSFORMATION") == 3
+    # every instance AXIS2 must be listed among the shared world rep's items
+    assert data.count("SHAPE_REPRESENTATION('model'") == 1
+
+    # Read-back through the native stream reader: 1 root, all 3 placements recovered.
+    roots = _roots(out)
+    assert len(roots) == 1
+    meta = roots[0][1]
+    assert len(meta.transforms) == 3
+    assert _translations(meta) == _EXPECT_TRANSLATIONS
+    # The rotated instance survives: one transform has x-axis ~(0,1,0).
+    rot = [t for t in meta.transforms if abs(t[0]) < 1e-4 and abs(t[1] - 1.0) < 1e-4]
+    assert len(rot) == 1
+
+
+def test_bake_env_restores_flat_form(src, tmp_path, monkeypatch):
+    monkeypatch.setenv("ADACPP_STEP_BAKE_INSTANCES", "1")
+    out = tmp_path / "baked.stp"
+    st = cad.stream_step_to_step(str(src), str(out))
+    assert st["solids_in"] == 1
+    assert st["instances_out"] == 3
+    data = out.read_text()
+    assert data.count("MANIFOLD_SOLID_BREP") == 3, "forced bake must emit one full B-rep per placement"
+    assert data.count("CONTEXT_DEPENDENT_SHAPE_REPRESENTATION") == 0
+    assert data.count("NEXT_ASSEMBLY_USAGE_OCCURRENCE") == 0
+    # Read-back: 3 flat roots, one placement each.
+    roots = _roots(out)
+    assert len(roots) == 3
+    assert all(len(m.transforms) in (0, 1) for _n, m in roots)
+
+
+def _stl_stats(path):
+    """(n_triangles, bbox_min, bbox_max) from a binary STL (80B header, u32 count, 50B/tri)."""
+    import struct
+
+    import numpy as np
+
+    raw = path.read_bytes()
+    (n,) = struct.unpack_from("<I", raw, 80)
+    tris = np.frombuffer(raw, dtype=np.uint8, offset=84).reshape(n, 50)
+    verts = tris[:, 12:48].copy().view("<f4").reshape(n, 3, 3).reshape(-1, 3)
+    return n, verts.min(axis=0), verts.max(axis=0)
+
+
+def test_mapped_and_baked_agree_geometrically(src, tmp_path, monkeypatch):
+    """The mapped file and the baked file must tessellate to the SAME world-space triangles
+    (stream_step_to_mesh bakes per-instance placements)."""
+    import numpy as np
+
+    mapped, baked = tmp_path / "m.stp", tmp_path / "b.stp"
+    cad.stream_step_to_step(str(src), str(mapped))
+    monkeypatch.setenv("ADACPP_STEP_BAKE_INSTANCES", "1")
+    cad.stream_step_to_step(str(src), str(baked))
+    monkeypatch.delenv("ADACPP_STEP_BAKE_INSTANCES")
+
+    stl_m, stl_b = tmp_path / "m.stl", tmp_path / "b.stl"
+    nm = cad.stream_step_to_mesh(str(mapped), str(stl_m), "stl")
+    nb = cad.stream_step_to_mesh(str(baked), str(stl_b), "stl")
+    assert nm == nb > 0, f"triangle counts diverge: mapped={nm} baked={nb}"
+    tm, mn_m, mx_m = _stl_stats(stl_m)
+    tb, mn_b, mx_b = _stl_stats(stl_b)
+    assert tm == tb == nm
+    assert np.allclose(mn_m, mn_b, atol=1e-5) and np.allclose(mx_m, mx_b, atol=1e-5)
+    # instancing really placed the copies: extents span all three placements of the unit cube
+    assert mx_m[0] - mn_m[0] >= 3.0 - 1e-4  # x: cube at 0 + cube at +2
+    assert mx_m[1] - mn_m[1] >= 4.0 - 1e-4  # y: cube at +3 (rotated)
+
+
+def test_step_parity_counts_mapped_instances(src):
+    d = cad.step_parity(str(src))
+    assert d["total_instances"] == 3
+    assert d["step"]["instances"] == 3
+    assert d["ifc"]["instances"] == 3
+    assert d["step"]["faces_dropped"] == 0
+
+
+def test_rotation_math_sanity():
+    # the rotated placement really is a 90 deg z-rotation
+    loc, z, x = _PLACEMENTS[2]
+    assert math.isclose(sum(a * b for a, b in zip(z, x)), 0.0, abs_tol=1e-12)


### PR DESCRIPTION
## AP242 assembly instancing in the STEP→STEP stream writer

Repeated solids were baked as a full `MANIFOLD_SOLID_BREP` per placement. They now emit ONE prototype `ADVANCED_BREP_SHAPE_REPRESENTATION` plus a per-placement `NEXT_ASSEMBLY_USAGE_OCCURRENCE` + `CONTEXT_DEPENDENT_SHAPE_REPRESENTATION` + `ITEM_DEFINED_TRANSFORMATION` — the assembly-instancing form both downstream readers (the kernel-free stream reader and OCC) already parse; `MAPPED_ITEM` was rejected because neither reader consumes it.

Measured on a 7,291-solid / 20,979-instance production model:
- output: 2.63 GB → 1.03 GB (**2.55x smaller**), faces serialized 689k → 302k
- emit wall: 1.88x faster; end-to-end conversion time roughly halves once transfer/compression scale down with it
- read-back: all 20,979 instances preserved across the stream reader, the pure-Python reader and OCC; tessellated output is *closer* to the source than the baked form (transform-baking degrades curved surfaces)

Safety rails: only rigid (orthonormal, det=+1) placements of B-rep solids are instanced — analytic solids and scaled/mirrored placements stay baked; `ADACPP_STEP_BAKE_INSTANCES=1` restores the old all-baked emit; single-instance output is byte-identical to before. `step_parity` mirrors the writer so instance metrics are unchanged, and the stats dict gains `instances_out`.

## Tessellation: reversed closed B-spline boundary edges dropped whole periodic faces

Two bugs that together accounted for ~90% of dropped faces across a NURBS-heavy STEP corpus (worst files lost 6–10% of their faces; all such files now tessellate with **0** drops, verified per file):

1. `OrientedEdgeN::discretize` picked a B-spline edge's direction by comparing endpoint distances — a tie on a *closed* edge (start vertex == end vertex, e.g. a full rational NURBS circle rim), so reversed (`.F.`) edges silently kept the curve's natural direction. A closed NURBS tube then unwrapped to winding w=2 and the periodic tessellator's |w|==1 gate dropped the whole face. Closed edges now reverse iff `same_sense != orientation`, matching the circle/ellipse path.
2. With (1) fixed, some loops legitimately unwrap into `u ∈ [-period, 0]`; `full_patch_rect` clamped the UV bbox into the knot domain, collapsing the rect to zero width → a "successful" 0-triangle tessellation. Loops are now shifted by the integer period into the knot domain, and a clamp-collapsed rect falls through to the trim-respecting emit path.

Remaining corpus drops are provably malformed source geometry (2-line sliver faces, point-collapsed B-spline rims, boundaries far off their referenced surface) — correct to drop.

## Tests
- New C++ regression `test_closed_bspline_edge_reversal_and_tube` (fails 3 checks without the fix) + new `tests/py/test_step_mapped_instances.py` (6 tests: multi-instance emit, read-back, env fallback, STL geometric parity, `step_parity` counts)
- All ngeom/step C++ suites and the full pytest suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTPCx8QJ8uDQB5RJViVct1